### PR TITLE
Fix for bug when terms resource had filter not matching anything.

### DIFF
--- a/src/main/java/com/github/flaxsearch/resources/TermsResource.java
+++ b/src/main/java/com/github/flaxsearch/resources/TermsResource.java
@@ -54,7 +54,6 @@ public class TermsResource {
             return Collections.emptyList();
 
         TermsEnum te = getTermsEnum(terms, filter);
-        System.out.println("te=" + te);
         List<String> collected = new ArrayList<>();
 
         boolean hasTerms = true;

--- a/src/main/java/com/github/flaxsearch/resources/TermsResource.java
+++ b/src/main/java/com/github/flaxsearch/resources/TermsResource.java
@@ -54,20 +54,26 @@ public class TermsResource {
             return Collections.emptyList();
 
         TermsEnum te = getTermsEnum(terms, filter);
+        System.out.println("te=" + te);
         List<String> collected = new ArrayList<>();
 
+        boolean hasTerms = true;
         if (startTerm != null) {
             if (te.seekCeil(new BytesRef(startTerm)) == TermsEnum.SeekStatus.END)
                 return Collections.emptyList();
         }
         else {
-            te.next();
+            if (te.next() == null) {
+                hasTerms = false;
+            }
         }
 
-        do {
-            collected.add(te.term().utf8ToString());
+        if (hasTerms) {
+            do {
+                collected.add(te.term().utf8ToString());
+            }
+            while (te.next() != null && --count > 0);
         }
-        while (te.next() != null && --count > 0);
 
         return collected;
     }

--- a/src/test/java/com/github/flaxsearch/resources/TestTermsResource.java
+++ b/src/test/java/com/github/flaxsearch/resources/TestTermsResource.java
@@ -62,4 +62,11 @@ public class TestTermsResource extends IndexResourceTestBase {
                 .get(new GenericType<List<String>>() {});
         assertThat(terms).containsExactly("value21");
     }
+
+    @Test
+    public void testTermsNoValueFilter() {
+        List<String> terms = resource.client().target("/terms/field3?filter=nomatch").request()
+                .get(new GenericType<List<String>>() {});
+        assertThat(terms).isEmpty();
+    }
 }


### PR DESCRIPTION
Code now tests for the TermsEnum being empty, and if so avoids calling .term() on it.