### PR TITLE
Add encoding options to /terms list

### DIFF
--- a/src/main/java/com/github/flaxsearch/api/TermsData.java
+++ b/src/main/java/com/github/flaxsearch/api/TermsData.java
@@ -18,10 +18,12 @@ package com.github.flaxsearch.api;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.function.Function;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.lucene.index.Terms;
+import org.apache.lucene.util.BytesRef;
 
 public class TermsData {
 
@@ -35,11 +37,11 @@ public class TermsData {
 
     public final List<String> terms;
 
-    public TermsData(Terms terms, List<String> termsList) throws IOException {
+    public TermsData(Terms terms, List<String> termsList, Function<BytesRef, String> formatter) throws IOException {
         this.termCount = terms.size();
         this.docCount = terms.getDocCount();
-        this.minTerm = terms.getMin().utf8ToString();
-        this.maxTerm = terms.getMax().utf8ToString();
+        this.minTerm = formatter.apply(terms.getMin());
+        this.maxTerm = formatter.apply(terms.getMax());
         this.terms = termsList;
     }
 

--- a/src/main/java/com/github/flaxsearch/api/TermsData.java
+++ b/src/main/java/com/github/flaxsearch/api/TermsData.java
@@ -18,12 +18,11 @@ package com.github.flaxsearch.api;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.function.Function;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.flaxsearch.util.BytesRefUtils;
 import org.apache.lucene.index.Terms;
-import org.apache.lucene.util.BytesRef;
 
 public class TermsData {
 
@@ -37,11 +36,11 @@ public class TermsData {
 
     public final List<String> terms;
 
-    public TermsData(Terms terms, List<String> termsList, Function<BytesRef, String> formatter) throws IOException {
+    public TermsData(Terms terms, List<String> termsList, String encoding) throws IOException {
         this.termCount = terms.size();
         this.docCount = terms.getDocCount();
-        this.minTerm = formatter.apply(terms.getMin());
-        this.maxTerm = formatter.apply(terms.getMax());
+        this.minTerm = BytesRefUtils.encode(terms.getMin(), encoding);
+        this.maxTerm = BytesRefUtils.encode(terms.getMax(), encoding);
         this.terms = termsList;
     }
 

--- a/src/main/java/com/github/flaxsearch/util/BytesRefUtils.java
+++ b/src/main/java/com/github/flaxsearch/util/BytesRefUtils.java
@@ -28,7 +28,17 @@ import org.apache.lucene.util.NumericUtils;
 
 public class BytesRefUtils {
 
-    public static Function<String, BytesRef> getDecoder(String type) {
+    public static String encode(BytesRef data, String encoding) {
+        Function<BytesRef, String> encoder = getEncoder(encoding);
+        return encoder.apply(data);
+    }
+
+    public static BytesRef decode(String data, String encoding) {
+        Function<String, BytesRef> decoder = getDecoder(encoding);
+        return decoder.apply(data);
+    }
+
+    private static Function<String, BytesRef> getDecoder(String type) {
         switch (type.toLowerCase(Locale.ROOT)) {
             case "base64" :
                 return s -> new BytesRef(Base64.getUrlDecoder().decode(s.getBytes(Charset.defaultCharset())));
@@ -63,7 +73,7 @@ public class BytesRefUtils {
         }
     }
 
-    public static Function<BytesRef, String> getEncoder(String type) {
+    private static Function<BytesRef, String> getEncoder(String type) {
         switch (type.toLowerCase(Locale.ROOT)) {
             case "base64" :
                 return b -> new String(Base64.getUrlEncoder().encode(b.bytes), Charset.defaultCharset());

--- a/src/main/java/com/github/flaxsearch/util/BytesRefUtils.java
+++ b/src/main/java/com/github/flaxsearch/util/BytesRefUtils.java
@@ -1,0 +1,85 @@
+package com.github.flaxsearch.util;
+
+/*
+ *   Copyright (c) 2016 Lemur Consulting Ltd.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+import java.nio.charset.Charset;
+import java.util.Base64;
+import java.util.Locale;
+import java.util.function.Function;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.LegacyNumericUtils;
+import org.apache.lucene.util.NumericUtils;
+
+public class BytesRefUtils {
+
+    public static Function<String, BytesRef> getDecoder(String type) {
+        switch (type.toLowerCase(Locale.ROOT)) {
+            case "base64" :
+                return s -> new BytesRef(Base64.getUrlDecoder().decode(s.getBytes(Charset.defaultCharset())));
+            case "utf8" :
+                return BytesRef::new;
+            case "int" :
+                return s -> {
+                    BytesRefBuilder builder = new BytesRefBuilder();
+                    LegacyNumericUtils.intToPrefixCoded(Integer.parseInt(s), 0, builder);
+                    return builder.get();
+                };
+            case "long" :
+                return s -> {
+                    BytesRefBuilder builder = new BytesRefBuilder();
+                    LegacyNumericUtils.longToPrefixCoded(Long.parseLong(s), 0, builder);
+                    return builder.get();
+                };
+            case "float" :
+                return s -> {
+                    BytesRefBuilder builder = new BytesRefBuilder();
+                    LegacyNumericUtils.intToPrefixCoded(NumericUtils.floatToSortableInt(Float.parseFloat(s)), 0, builder);
+                    return builder.get();
+                };
+            case "double" :
+                return s -> {
+                    BytesRefBuilder builder = new BytesRefBuilder();
+                    LegacyNumericUtils.longToPrefixCoded(NumericUtils.doubleToSortableLong(Double.parseDouble(s)), 0, builder);
+                    return builder.get();
+                };
+            default :
+                throw new IllegalArgumentException("Unknown decoder type: " + type);
+        }
+    }
+
+    public static Function<BytesRef, String> getEncoder(String type) {
+        switch (type.toLowerCase(Locale.ROOT)) {
+            case "base64" :
+                return b -> new String(Base64.getUrlEncoder().encode(b.bytes), Charset.defaultCharset());
+            case "utf8" :
+                return BytesRef::utf8ToString;
+            case "int" :
+                return b -> Integer.toString(LegacyNumericUtils.prefixCodedToInt(b));
+            case "long" :
+                return b -> Long.toString(LegacyNumericUtils.prefixCodedToLong(b));
+            case "float" :
+                return b -> Float.toString(NumericUtils.sortableIntToFloat(LegacyNumericUtils.prefixCodedToInt(b)));
+            case "double" :
+                return b -> Double.toString(NumericUtils.sortableLongToDouble(LegacyNumericUtils.prefixCodedToLong(b)));
+            default:
+                throw new IllegalArgumentException("Unknown encoder type: " + type);
+        }
+    }
+
+}

--- a/ui/src/app.js
+++ b/ui/src/app.js
@@ -45,12 +45,13 @@ class MarpleContent extends React.Component {
   }
 
   selectField(fieldName) {
-    loadTermsData(this.state.selectedSegment, fieldName, '', this.state.encoding,
+    loadTermsData(this.state.selectedSegment, fieldName, '', "utf8",
       termsData => {
         this.setState({
           termsData,
           selectedField: fieldName,
-          termsFilter: ''
+          termsFilter: '',
+            encoding: "utf8"
         });
       },
       errorMsg => handleError(errorMsg));

--- a/ui/src/app.js
+++ b/ui/src/app.js
@@ -18,12 +18,14 @@ class MarpleContent extends React.Component {
       fieldsData: [],
       selectedField: undefined,
       selectedSegment: undefined,
+      encoding: 'utf8',
       termsFilter: ''
     };
 
     this.selectSegment = this.selectSegment.bind(this);
     this.selectField = this.selectField.bind(this);
     this.setTermsFilter = this.setTermsFilter.bind(this);
+    this.setEncoding = this.setEncoding.bind(this);
   }
 
   componentDidMount() {
@@ -43,7 +45,7 @@ class MarpleContent extends React.Component {
   }
 
   selectField(fieldName) {
-    loadTermsData(this.state.selectedSegment, fieldName, '',
+    loadTermsData(this.state.selectedSegment, fieldName, '', this.state.encoding,
       termsData => {
         this.setState({
           termsData,
@@ -56,11 +58,18 @@ class MarpleContent extends React.Component {
 
   setTermsFilter(termsFilter) {
     loadTermsData(this.state.selectedSegment,
-      this.state.selectedField, termsFilter,
+      this.state.selectedField, termsFilter, this.state.encoding,
       termsData => {
         this.setState({ termsData, termsFilter });
       },
       errorMsg => handleError(errorMsg));
+  }
+
+  setEncoding(encoding) {
+      loadTermsData(this.state.selectedSegment, this.state.selectedField, this.state.termsFilter,
+      encoding, termsData => {
+          this.setState({ termsData, encoding });
+      }, errorMsg => handleError(errorMsg));
   }
 
   render() {
@@ -79,9 +88,11 @@ class MarpleContent extends React.Component {
         </Col>
         <Col md={6}>
           <FieldData field={this.state.selectedField}
-           termsData={this.state.termsData}
-           termsFilter={this.state.termsFilter}
-           setTermsFilter={this.setTermsFilter}
+                     termsData={this.state.termsData}
+                     termsFilter={this.state.termsFilter}
+                     setTermsFilter={this.setTermsFilter}
+                     encoding={this.state.encoding}
+                     selectEncoding={this.setEncoding}
            />
         </Col>
       </div>

--- a/ui/src/components.js
+++ b/ui/src/components.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 
-import { Navbar, Nav, NavItem, FormGroup, FormControl } from 'react-bootstrap';
+import { Navbar, Nav, NavItem, FormGroup, FormControl, Radio } from 'react-bootstrap';
 
 export const MarpleNav = props => {
   return (
@@ -42,6 +42,18 @@ export const Segments = props => {
   );
 };
 
+export const Encoding = props => {
+    const buttons = [ "utf8", "base64", "int", "long", "float", "double" ].map(function(encoding) {
+        return (
+            <Radio inline value={encoding} checked={props.encoding == encoding}
+                   onChange={ e => props.selectEncoding(e.target.value) }>
+            {encoding}
+            </Radio>
+        );
+    });
+    return (<FormGroup>{buttons}</FormGroup>);
+};
+
 export const TermsData = props => {
   var termsList = props.terms.terms.map(function(term) {
     return (<NavItem key={term}>{term}</NavItem>)
@@ -64,6 +76,7 @@ export const TermsData = props => {
       <form style={style} onSubmit={ e => e.preventDefault() }>
           <FormControl type="text" placeholder="Filter" value={props.termsFilter}
             onChange={ e => props.setTermsFilter(e.target.value) } />
+          <Encoding encoding={props.encoding} selectEncoding={props.selectEncoding}/>
       </form>
 
       <Nav>{termsList}</Nav>
@@ -82,8 +95,12 @@ export const FieldData = props => {
         <NavItem eventKey="docvalues">DocValues</NavItem>
         <NavItem eventKey="points">Points</NavItem>
       </Nav>
-      <TermsData terms={props.termsData} termsFilter={props.termsFilter}
-        setTermsFilter={props.setTermsFilter}/>
+      <TermsData terms={props.termsData}
+                 termsFilter={props.termsFilter}
+                 setTermsFilter={props.setTermsFilter}
+                 encoding={props.encoding}
+                 selectEncoding={props.selectEncoding}
+      />
     </div>
   );
 };

--- a/ui/src/data.js
+++ b/ui/src/data.js
@@ -22,13 +22,20 @@ export function loadFieldsData(segment, onSuccess, onError) {
   .catch(error => { onError('error loading fields data: ' + error); });
 }
 
+function checkStatus(response) {
+    if (response.status >= 200 && response.status < 300)
+        return Promise.resolve(response);
+    return response.json().then(json => Promise.reject(new Error(json.message)));
+}
+
 export function loadTermsData(segment, field, termsFilter, encoding, onSuccess, onError) {
-  // add a wildcard to the end of the filter
+    // add a wildcard to the end of the filter
   const filter = termsFilter ? termsFilter + '.*' : '';
-  const url = MARPLE_BASE + `/api/terms/${field}?` + makeQueryStr({ segment, filter, encoding });
-  console.log('FIXME url=' + url);
-  fetch(url)
-  .then(response => response.json())
-  .then(data => { onSuccess(data); })
-  .catch(error => { onError('error loading terms data: ' + error); });
+    const url = MARPLE_BASE + `/api/terms/${field}?` + makeQueryStr({ segment, filter, encoding });
+    fetch(url)
+        .then(checkStatus)
+        .then(response => response.json())
+        .then(data => { onSuccess(data); })
+        .catch(error => { onError('error loading terms data: ' + error); });
+    console.log('FIXME url=' + url);
 }

--- a/ui/src/data.js
+++ b/ui/src/data.js
@@ -22,10 +22,10 @@ export function loadFieldsData(segment, onSuccess, onError) {
   .catch(error => { onError('error loading fields data: ' + error); });
 }
 
-export function loadTermsData(segment, field, termsFilter, onSuccess, onError) {
+export function loadTermsData(segment, field, termsFilter, encoding, onSuccess, onError) {
   // add a wildcard to the end of the filter
   const filter = termsFilter ? termsFilter + '.*' : '';
-  const url = MARPLE_BASE + `/api/terms/${field}?` + makeQueryStr({ segment, filter });
+  const url = MARPLE_BASE + `/api/terms/${field}?` + makeQueryStr({ segment, filter, encoding });
   console.log('FIXME url=' + url);
   fetch(url)
   .then(response => response.json())


### PR DESCRIPTION
This allows you to choose how the terms should be displayed (eg can translate
them into numeric fields, or base64 for arbitrary bytes)