### PR TITLE
Simplify docvalues api

### DIFF
--- a/src/main/java/com/github/flaxsearch/api/AnyDocValuesResponse.java
+++ b/src/main/java/com/github/flaxsearch/api/AnyDocValuesResponse.java
@@ -4,6 +4,10 @@ public class AnyDocValuesResponse {
 	private String type;
 	private Object values;
 
+	public AnyDocValuesResponse() {
+		// required for unit test
+	}
+
 	public AnyDocValuesResponse(String type, Object values) {
 		this.type = type;
 		this.values = values;

--- a/src/main/java/com/github/flaxsearch/api/AnyDocValuesResponse.java
+++ b/src/main/java/com/github/flaxsearch/api/AnyDocValuesResponse.java
@@ -1,0 +1,19 @@
+package com.github.flaxsearch.api;
+
+public class AnyDocValuesResponse {
+	private String type;
+	private Object values;
+
+	public AnyDocValuesResponse(String type, Object values) {
+		this.type = type;
+		this.values = values;
+	}
+	
+	public String getType() {
+		return type;
+	}
+	
+	public Object getValues() {
+		return values;
+	}
+}

--- a/src/main/java/com/github/flaxsearch/resources/DocValuesResource.java
+++ b/src/main/java/com/github/flaxsearch/resources/DocValuesResource.java
@@ -21,14 +21,20 @@ import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.HashMap;
 
 import com.github.flaxsearch.util.ReaderManager;
+import com.github.flaxsearch.api.AnyDocValuesResponse;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
-import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.FieldInfo;
 
 
 @Path("/docvalues/{field}")
@@ -41,12 +47,87 @@ public class DocValuesResource {
         this.readerManager = readerManager;
     }
 
+    @GET
+    public AnyDocValuesResponse getAnyTypeDocValues(@QueryParam("segment") Integer segment,
+                                            @PathParam("field") String field,
+                                            @QueryParam("docs") String docs)
+                                            throws IOException {
+    	AnyDocValuesResponse response = null;
+        int maxDoc = readerManager.getMaxDoc(segment);
+        Set<Integer> docset = parseDocSet(docs, maxDoc);
+        FieldInfo fieldInfo = readerManager.getFieldInfo(segment, field);
+
+        if (fieldInfo == null) {
+            String msg = String.format("No such field %s", field);
+            throw new WebApplicationException(msg, Response.Status.NOT_FOUND);
+        }
+
+        DocValuesType dvtype = fieldInfo.getDocValuesType();
+        if (dvtype == DocValuesType.BINARY) {
+            BinaryDocValues dv = readerManager.getBinaryDocValues(segment, field);
+            Map<Integer,String> values = new HashMap<>(docset.size());
+            for (int docid : docset) {
+                values.put(docid, dv.get(docid).utf8ToString());
+            }
+            response = new AnyDocValuesResponse("BINARY", values);
+        }
+        else if (dvtype == DocValuesType.NUMERIC) {
+            NumericDocValues dv = readerManager.getNumericDocValues(segment, field);
+            Map<Integer,String> values = new HashMap<>(docset.size());
+            for (int docid : docset) {
+                values.put(docid, Long.toString(dv.get(docid)));
+            }
+            response = new AnyDocValuesResponse("NUMERIC", values);
+        }
+        else if (dvtype == DocValuesType.SORTED) {
+            SortedDocValues dv = readerManager.getSortedDocValues(segment, field);
+            Map<Integer,String> values = new HashMap<>(docset.size());
+            for (int docid : docset) {
+                values.put(docid, dv.get(docid).utf8ToString());
+            }
+            response = new AnyDocValuesResponse("SORTED", values);
+        }
+        else if (dvtype == DocValuesType.SORTED_NUMERIC) {
+            SortedNumericDocValues dv = readerManager.getSortedNumericDocValues(segment, field);
+            Map<Integer,List<String>> values = new HashMap<>(docset.size());
+            for (int docid : docset) {
+                dv.setDocument(docid);
+                List<String> perDocValues = new ArrayList<>(dv.count());
+                for (int index = 0; index < dv.count(); ++index) {
+                    perDocValues.add(Long.toString(dv.valueAt(index)));
+                }
+                values.put(docid, perDocValues);
+            }
+            response = new AnyDocValuesResponse("SORTED_NUMERIC", values);
+        }
+        else if (dvtype == DocValuesType.SORTED_SET) {
+            SortedSetDocValues dv = readerManager.getSortedSetDocValues(segment, field);
+            Map<Integer,List<String>> values = new HashMap<>(docset.size());
+            for (int docid : docset) {
+                dv.setDocument(docid);
+                List<String> perDocValues = new ArrayList<String>((int)dv.getValueCount());
+                long ord;
+                while ((ord = dv.nextOrd()) != SortedSetDocValues.NO_MORE_ORDS) {
+                    perDocValues.add(dv.lookupOrd(ord).utf8ToString());
+                }
+                values.put(docid, perDocValues);
+            }
+            response = new AnyDocValuesResponse("SORTED_SET", values);
+        }
+        else {
+            String msg = String.format("No doc values for field %s", field);
+            throw new WebApplicationException(msg, Response.Status.NOT_FOUND);
+        }
+
+        return response;
+    }
+
     @Path("/binary")
     @GET
     public List<String> getBinaryDocValues(@QueryParam("segment") Integer segment,
-                                                  @PathParam("field") String field,
-                                                  @QueryParam("from") @DefaultValue("0") int fromDoc,
-                                                  @QueryParam("count") @DefaultValue("50") int count) throws IOException {
+                                            @PathParam("field") String field,
+                                            @QueryParam("from") @DefaultValue("0") int fromDoc,
+                                            @QueryParam("count") @DefaultValue("50") int count) throws IOException {
 
         List<String> values = new ArrayList<>(count);
         int maxDoc = readerManager.getMaxDoc(segment);
@@ -161,4 +242,36 @@ public class DocValuesResource {
 
         return values;
     }
+    
+    public static Set<Integer> parseDocSet(String docs, int maxDoc) {
+    	Set<Integer> docset = new HashSet<>();
+    	for (String chunk : docs.split(",")) {
+    		chunk = chunk.trim();
+    		if (chunk.contains("-")) {
+    			String[] range_s = chunk.split("-");
+    			if (range_s.length != 2) {
+    				String msg = String.format("Incorrect range format \"%s\" in docs", chunk);
+    	            throw new WebApplicationException(msg, Response.Status.BAD_REQUEST);
+    			}
+    			
+    			int range_from = Integer.parseInt(range_s[0]);
+    			int range_to = Integer.parseInt(range_s[1]);
+    			if (range_from > range_to) {
+    				String msg = String.format("Incorrect range \"%s\" in docs", chunk);
+    	            throw new WebApplicationException(msg, Response.Status.BAD_REQUEST);    				
+    			}
+    			
+    			int i;
+    			for (i = range_from; i <= range_to; i++) {
+    				docset.add(i);
+    			}
+    		}
+    		else {
+    			docset.add(Integer.parseInt(chunk));
+    		}
+    	}
+    	
+    	return docset;
+    }
+
 }

--- a/src/main/java/com/github/flaxsearch/resources/DocValuesResource.java
+++ b/src/main/java/com/github/flaxsearch/resources/DocValuesResource.java
@@ -83,6 +83,7 @@ public class DocValuesResource {
             SortedDocValues dv = readerManager.getSortedDocValues(segment, field);
             Map<Integer,String> values = new HashMap<>(docset.size());
             for (int docid : docset) {
+            	System.out.println("FIXME docid=" + docid);
                 values.put(docid, dv.get(docid).utf8ToString());
             }
             response = new AnyDocValuesResponse("SORTED", values);
@@ -245,32 +246,39 @@ public class DocValuesResource {
     
     public static Set<Integer> parseDocSet(String docs, int maxDoc) {
     	Set<Integer> docset = new HashSet<>();
-    	for (String chunk : docs.split(",")) {
-    		chunk = chunk.trim();
-    		if (chunk.contains("-")) {
-    			String[] range_s = chunk.split("-");
-    			if (range_s.length != 2) {
-    				String msg = String.format("Incorrect range format \"%s\" in docs", chunk);
-    	            throw new WebApplicationException(msg, Response.Status.BAD_REQUEST);
-    			}
-    			
-    			int range_from = Integer.parseInt(range_s[0]);
-    			int range_to = Integer.parseInt(range_s[1]);
-    			if (range_from > range_to) {
-    				String msg = String.format("Incorrect range \"%s\" in docs", chunk);
-    	            throw new WebApplicationException(msg, Response.Status.BAD_REQUEST);    				
-    			}
-    			
-    			int i;
-    			for (i = range_from; i <= range_to; i++) {
-    				docset.add(i);
-    			}
-    		}
-    		else {
-    			docset.add(Integer.parseInt(chunk));
+    	if (docs == null) {
+    		// return default set
+    		for (int i = 0; i < 100 && i < maxDoc; i++) {
+    			docset.add(i);
     		}
     	}
-    	
+    	else {
+	    	for (String chunk : docs.split(",")) {
+	    		chunk = chunk.trim();
+	    		if (chunk.contains("-")) {
+	    			String[] range_s = chunk.split("-");
+	    			if (range_s.length != 2) {
+	    				String msg = String.format("Incorrect range format \"%s\" in docs", chunk);
+	    	            throw new WebApplicationException(msg, Response.Status.BAD_REQUEST);
+	    			}
+	    			
+	    			int range_from = Integer.parseInt(range_s[0]);
+	    			int range_to = Integer.parseInt(range_s[1]);
+	    			if (range_from > range_to) {
+	    				String msg = String.format("Incorrect range \"%s\" in docs", chunk);
+	    	            throw new WebApplicationException(msg, Response.Status.BAD_REQUEST);    				
+	    			}
+	    			
+	    			int i;
+	    			for (i = range_from; i <= range_to; i++) {
+	    				docset.add(i);
+	    			}
+	    		}
+	    		else {
+	    			docset.add(Integer.parseInt(chunk));
+	    		}
+	    	}
+    	}
     	return docset;
     }
 

--- a/src/main/java/com/github/flaxsearch/util/ReaderManager.java
+++ b/src/main/java/com/github/flaxsearch/util/ReaderManager.java
@@ -39,6 +39,10 @@ public interface ReaderManager {
         return getLeafReader(segment).getFieldInfos();
     }
 
+    default FieldInfo getFieldInfo(Integer segment, String fieldname) throws IOException {
+        return getFieldInfos(segment).fieldInfo(fieldname);
+    }
+
     default Bits getLiveDocs(Integer segment) throws IOException {
         if (segment == null)
             return MultiFields.getLiveDocs(getIndexReader());

--- a/src/test/java/com/github/flaxsearch/resources/TestDocValuesResource.java
+++ b/src/test/java/com/github/flaxsearch/resources/TestDocValuesResource.java
@@ -18,6 +18,7 @@ package com.github.flaxsearch.resources;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.GenericType;
 import java.util.List;
+import java.util.Map;
 
 import io.dropwizard.testing.junit.ResourceTestRule;
 import org.junit.ClassRule;
@@ -25,6 +26,8 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+
+import com.github.flaxsearch.api.AnyDocValuesResponse;
 
 public class TestDocValuesResource extends IndexResourceTestBase {
 
@@ -47,5 +50,16 @@ public class TestDocValuesResource extends IndexResourceTestBase {
         } catch (NotFoundException e) {
             // Expected: HTTP 404 Not Found 
         }
+    }
+    
+    @Test
+    public void testAnyDocValues() {
+        AnyDocValuesResponse response = resource.client().target("/docvalues/field1").request()
+                .get(new GenericType<AnyDocValuesResponse>() {});
+    	assertThat(response.getType()).isEqualTo("BINARY");
+    	assertThat(response.getValues()).isInstanceOf(Map.class);
+    	Map<String,String> values = (Map<String,String>) response.getValues();
+    	assertThat(values.get("0")).isEqualTo("");
+    	assertThat(values.get("1")).isEqualTo("some bytes");
     }
 }

--- a/src/test/java/com/github/flaxsearch/testutil/GutenbergIndex.java
+++ b/src/test/java/com/github/flaxsearch/testutil/GutenbergIndex.java
@@ -25,6 +25,8 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.util.BytesRef;
+
 
 public class GutenbergIndex {
 
@@ -54,11 +56,23 @@ public class GutenbergIndex {
     }
 
     public static Document buildDocument(Path source, byte[] data) {
+        String filename = source.getFileName().toString();
+        String filepath = source.toString();
+        String fileparent = source.getParent().toString();
+
         Document document = new Document();
         document.add(new TextField("text", new String(data, Charset.defaultCharset()), Field.Store.YES));
-        document.add(new StringField("source", source.toString(), Field.Store.YES));
+        document.add(new StringField("source", filepath, Field.Store.YES));
         document.add(new IntPoint("filesize", data.length));
         document.add(new NumericDocValuesField("filesize", data.length));
+
+        document.add(new SortedDocValuesField("dv_filepath", new BytesRef(filepath)));
+        document.add(new BinaryDocValuesField("dv_filename", new BytesRef(filename)));
+        document.add(new SortedNumericDocValuesField("dv_filesize_sorted", data.length));
+        document.add(new SortedSetDocValuesField("dv_filename_set", new BytesRef(filename)));
+        document.add(new SortedSetDocValuesField("dv_filename_set", new BytesRef(filepath)));
+        document.add(new SortedSetDocValuesField("dv_filename_set", new BytesRef(fileparent)));
+
         return document;
     }
 


### PR DESCRIPTION
Added a new endpoint to the doc values resource:

    /api/docvalues/<field>[?docs={docset}]

which returns, e.g.:

    {
        "type": "BINARY",
        "values": {
            "1": "banana",
            "5": "apple",
            ...
        }
    }

The endpoint is intended to be used with the {docset} parameter, which allows the user to specify a set of document IDs, e.g.:

    ?docs=1,3,5-9,100-200

Without {docset}, the endpoint will return the values for up to the first hundred documents.