### PR TITLE
Make terms list a table

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 
     <properties>
         <dropwizard.version>1.0.0</dropwizard.version>
-        <lucene.version>6.2.0</lucene.version>
+        <lucene.version>6.4.0</lucene.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/com/github/flaxsearch/api/TermData.java
+++ b/src/main/java/com/github/flaxsearch/api/TermData.java
@@ -16,9 +16,6 @@ package com.github.flaxsearch.api;
  */
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.lucene.util.BytesRef;
-
-import java.util.List;
 
 public class TermData {
 
@@ -28,16 +25,12 @@ public class TermData {
 
     public final long totalTermFreq;
 
-    public final int[] postings;
-
     public TermData(@JsonProperty("term") String term,
                     @JsonProperty("docFreq") int docFreq,
-                    @JsonProperty("totalTermFreq") long totalTermFreq,
-                    @JsonProperty("postings") int[] postings) {
+                    @JsonProperty("totalTermFreq") long totalTermFreq) {
         this.term = term;
         this.docFreq = docFreq;
         this.totalTermFreq = totalTermFreq;
-        this.postings = postings;
     }
 
 }

--- a/src/main/java/com/github/flaxsearch/api/TermsData.java
+++ b/src/main/java/com/github/flaxsearch/api/TermsData.java
@@ -34,9 +34,9 @@ public class TermsData {
 
     public final String maxTerm;
 
-    public final List<String> terms;
+    public final List<TermData> terms;
 
-    public TermsData(Terms terms, List<String> termsList, String encoding) throws IOException {
+    public TermsData(Terms terms, List<TermData> termsList, String encoding) throws IOException {
         this.termCount = terms.size();
         this.docCount = terms.getDocCount();
         this.minTerm = BytesRefUtils.encode(terms.getMin(), encoding);
@@ -49,7 +49,7 @@ public class TermsData {
                      @JsonProperty("docCount") long docCount,
                      @JsonProperty("minTerm") String minTerm,
                      @JsonProperty("maxTerm") String maxTerm,
-                     @JsonProperty("terms") List<String> terms) {
+                     @JsonProperty("terms") List<TermData> terms) {
         this.termCount = termCount;
         this.docCount = docCount;
         this.minTerm = minTerm;

--- a/src/main/java/com/github/flaxsearch/resources/PostingsResource.java
+++ b/src/main/java/com/github/flaxsearch/resources/PostingsResource.java
@@ -19,7 +19,6 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 
-import com.github.flaxsearch.api.TermData;
 import com.github.flaxsearch.util.ReaderManager;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.TermsEnum;
@@ -36,7 +35,7 @@ public class PostingsResource {
     }
 
     @GET
-    public TermData getPostings(@QueryParam("segment") Integer segment,
+    public int[] getPostings(@QueryParam("segment") Integer segment,
                                 @PathParam("field") String field,
                                 @PathParam("term") String term,
                                 @QueryParam("count") @DefaultValue("2147483647") int count) throws IOException {
@@ -46,7 +45,6 @@ public class PostingsResource {
         PostingsEnum pe = te.postings(null, PostingsEnum.NONE);
 
         int docFreq = te.docFreq();
-        long totalTermFreq = te.totalTermFreq();
 
         int size = (docFreq < count) ? docFreq : count;
         int[] postings = new int[size];
@@ -57,7 +55,7 @@ public class PostingsResource {
             postings[i] = docId;
             i++;
         }
-        return new TermData(term, docFreq, totalTermFreq, postings);
+        return postings;
     }
 
 }

--- a/src/main/java/com/github/flaxsearch/resources/TermsResource.java
+++ b/src/main/java/com/github/flaxsearch/resources/TermsResource.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import com.github.flaxsearch.api.TermData;
 import com.github.flaxsearch.api.TermsData;
 import com.github.flaxsearch.util.BytesRefUtils;
 import com.github.flaxsearch.util.ReaderManager;
@@ -59,7 +60,7 @@ public class TermsResource {
                 throw new WebApplicationException("No such field " + field, Response.Status.NOT_FOUND);
 
             TermsEnum te = getTermsEnum(terms, filter);
-            List<String> collected = new ArrayList<>();
+            List<TermData> collected = new ArrayList<>();
 
             if (startTerm != null) {
                 BytesRef start = BytesRefUtils.decode(startTerm, encoding);
@@ -72,7 +73,8 @@ public class TermsResource {
             }
 
             do {
-                collected.add(BytesRefUtils.encode(te.term(), encoding));
+                TermData td = new TermData(BytesRefUtils.encode(te.term(), encoding), te.docFreq(), te.totalTermFreq());
+                collected.add(td);
             }
             while (te.next() != null && --count > 0);
 

--- a/src/test/java/com/github/flaxsearch/resources/TestPostingsResource.java
+++ b/src/test/java/com/github/flaxsearch/resources/TestPostingsResource.java
@@ -20,7 +20,6 @@ import javax.ws.rs.core.GenericType;
 import java.util.List;
 import java.util.Map;
 
-import com.github.flaxsearch.api.TermData;
 import io.dropwizard.testing.junit.ResourceTestRule;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -37,14 +36,11 @@ public class TestPostingsResource extends IndexResourceTestBase {
 
     @Test
     public void testWholeIndexPostings() {
-        TermData termData = resource.client().target("/postings/field3/field").request()
-                .get(TermData.class);
+        int[] postings = resource.client().target("/postings/field3/field").request()
+                .get(int[].class);
 
-        assertThat(termData).isNotNull();
-        assertThat(termData.term).isEqualTo("field");
-        assertThat(termData.docFreq).isEqualTo(1);
-        assertThat(termData.totalTermFreq).isEqualTo(1);
-        assertThat(termData.postings.length).isEqualTo(1);
+        assertThat(postings).isNotNull();
+        assertThat(postings).hasSize(1);
     }
 
     @Test

--- a/src/test/java/com/github/flaxsearch/resources/TestTermsResource.java
+++ b/src/test/java/com/github/flaxsearch/resources/TestTermsResource.java
@@ -38,7 +38,8 @@ public class TestTermsResource extends IndexResourceTestBase {
                 .get(TermsData.class);
 
         assertThat(terms.terms).hasSize(2);
-        assertThat(terms.terms).containsExactly("field", "more");
+        assertThat(terms.terms.get(0).term).isEqualTo("field");
+        assertThat(terms.terms.get(0).docFreq).isEqualTo(1);
     }
 
     @Test
@@ -59,14 +60,14 @@ public class TestTermsResource extends IndexResourceTestBase {
         TermsData terms = resource.client().target("/terms/field3?filter=value.1").request()
                 .get(TermsData.class);
 
-        assertThat(terms.terms).containsExactly("value11", "value21");
+        assertThat(terms.terms).extracting("term").containsExactly("value11", "value21");
     }
 
     @Test
     public void testTermsSingleValueFilter() {
         TermsData terms = resource.client().target("/terms/field3?filter=value21").request()
                 .get(TermsData.class);
-        assertThat(terms.terms).containsExactly("value21");
+        assertThat(terms.terms).extracting("term").containsExactly("value21");
     }
 
     @Test
@@ -80,11 +81,11 @@ public class TestTermsResource extends IndexResourceTestBase {
     public void testEncodings() {
         TermsData terms = resource.client().target("/terms/field1?encoding=utf8").request()
                 .get(TermsData.class);
-        assertThat(terms.terms).containsExactly("value1", "value2");
+        assertThat(terms.terms).extracting("term").containsExactly("value1", "value2");
         
         terms = resource.client().target("/terms/field1?encoding=base64").request()
                 .get(TermsData.class);
-        assertThat(terms.terms).containsExactly("dmFsdWUx", "dmFsdWUy");
+        assertThat(terms.terms).extracting("term").containsExactly("dmFsdWUx", "dmFsdWUy");
     }
     
 }

--- a/ui/src/components/postings.js
+++ b/ui/src/components/postings.js
@@ -5,7 +5,7 @@ import PostingItem from './postingitem';
 class Postings extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { };
+    this.state = { postingsData: [] };
     this.componentDidMount = this.componentDidMount.bind(this);
   }
 
@@ -16,7 +16,7 @@ class Postings extends React.Component {
 	  },
 	  errmsg => {
         if (errmsg.includes('No term')) {
-          this.setState({ postingsData: undefined });
+          this.setState({ postingsData: [] });
         }
         else {
           this.props.showAlert(errmsg, true);
@@ -28,11 +28,11 @@ class Postings extends React.Component {
     const s = this.state;
     const p = this.props;
 
-    if (s.postingsData == undefined) {
+    if (s.postingsData.length == 0) {
       return <div></div>;
     }
 
-    var postingList = s.postingsData.postings.map((docid, idx) =>
+    var postingList = s.postingsData.map((docid, idx) =>
       <PostingItem key={idx} segment={p.segment} field={p.field}
        term={p.term} docid={docid} showAlert={p.showAlert}/>
     );

--- a/ui/src/components/termitem.js
+++ b/ui/src/components/termitem.js
@@ -33,7 +33,7 @@ class TermItem extends React.Component {
     const postings = s.displayPostings ?
       <div style={POSTINGSSTYLE}>
         <Postings segment={p.segment} field={p.field}
-         term={p.term.term} showAlert={p.showAlert} />
+         term={p.term} showAlert={p.showAlert} />
       </div> : null;
 
     const toggle = s.displayPostings ?
@@ -42,7 +42,7 @@ class TermItem extends React.Component {
     return <div>
       <div><a href="#" onClick={ e => { e.preventDefault();
         this.handlePostingsClick() }}>
-        {p.term.term}
+        {p.term}
         <span className={'glyphicon ' + toggle}
               style={{ fontSize: '11px', paddingLeft: '5px', color: 'lightgrey' }}
               aria-hidden="true"></span>
@@ -57,7 +57,7 @@ TermItem.propTypes = {
     PropTypes.string, PropTypes.number
   ]),
   field: PropTypes.string.isRequired,
-  term: PropTypes.object.isRequired
+  term: PropTypes.string.isRequired
 }
 
 export default TermItem;

--- a/ui/src/components/termitem.js
+++ b/ui/src/components/termitem.js
@@ -33,7 +33,7 @@ class TermItem extends React.Component {
     const postings = s.displayPostings ?
       <div style={POSTINGSSTYLE}>
         <Postings segment={p.segment} field={p.field}
-         term={p.term} showAlert={p.showAlert} />
+         term={p.term.term} showAlert={p.showAlert} />
       </div> : null;
 
     const toggle = s.displayPostings ?
@@ -42,7 +42,7 @@ class TermItem extends React.Component {
     return <div>
       <div><a href="#" onClick={ e => { e.preventDefault();
         this.handlePostingsClick() }}>
-        {p.term}
+        {p.term.term}
         <span className={'glyphicon ' + toggle}
               style={{ fontSize: '11px', paddingLeft: '5px', color: 'lightgrey' }}
               aria-hidden="true"></span>
@@ -57,7 +57,7 @@ TermItem.propTypes = {
     PropTypes.string, PropTypes.number
   ]),
   field: PropTypes.string.isRequired,
-  term: PropTypes.string.isRequired
+  term: PropTypes.object.isRequired
 }
 
 export default TermItem;

--- a/ui/src/components/terms.js
+++ b/ui/src/components/terms.js
@@ -102,7 +102,11 @@ class Terms extends React.Component {
         return(
             <Table>
                 <thead>
-                <tr><td>term</td><td>docFreq</td><td>totalTermFreq</td></tr>
+                <tr>
+                    <td style={{ width:'80%' }}>term</td>
+                    <td>docFreq</td>
+                    <td>totalTermFreq</td>
+                </tr>
                 </thead>
                 <tbody>
                 {termEntries}

--- a/ui/src/components/terms.js
+++ b/ui/src/components/terms.js
@@ -84,18 +84,18 @@ class Terms extends React.Component {
         const p = this.props;
         const termEntries = s.termsData.terms.map((term, idx) => (
                 <tr key={idx}>
-                    <td>{term.docFreq}</td>
-                    <td>{term.totalTermFreq}</td>
                     <td>
                         <TermItem key={idx} segment={p.segment} field={p.field} term={term.term} showAlert={p.showAlert}/>
                     </td>
+                    <td>{term.docFreq}</td>
+                    <td>{term.totalTermFreq}</td>
                 </tr>
             ));
 
         return(
             <Table>
                 <thead>
-                <tr><td>docFreq</td><td>totalTermFreq</td><td>term</td></tr>
+                <tr><td>term</td><td>docFreq</td><td>totalTermFreq</td></tr>
                 </thead>
                 <tbody>
                 {termEntries}

--- a/ui/src/components/terms.js
+++ b/ui/src/components/terms.js
@@ -119,7 +119,7 @@ class Terms extends React.Component {
         <FormControl type="text" value={s.termsFilter}
          placeholder={'Filter by regexp'}
          onChange={ e => this.setTermsFilter(e.target.value) }
-         style={{width:'500px'}} />
+         style={{width:'75%'}} />
         {" "}
         <EncodingDropdown encoding={s.encoding} numeric={true}
                           onSelect={x => this.setEncoding(x)} />

--- a/ui/test/components/terms-test.js
+++ b/ui/test/components/terms-test.js
@@ -23,7 +23,9 @@ describe('components/terms', function() {
       "docCount": 19,
       "minTerm": "aardvark",
       "maxTerm": "zebra",
-      "terms": [ "aardvark", "bat", "cat" ]
+      "terms": [ { term : "aardvark", docFreq: 1, totalTermFreq: 1 } ,
+          { term : "bat", docFreq: 1, totalTermFreq: 1 },
+          { term : "cat", docFreq: 1, totalTermFreq: 1 } ]
     });
 
     fetchMock.get(MARPLE_BASE + '/api/terms/foo?segment=1&encoding=int', {

--- a/ui/test/components/terms-test.js
+++ b/ui/test/components/terms-test.js
@@ -56,14 +56,17 @@ describe('components/terms', function() {
     expect(renderedDOM.children[2].tagName).to.eql('DIV');
 
     const tds = renderedDOM.getElementsByTagName('TD');
-    expect(tds.length).to.eql(8);
+    expect(tds.length).to.eql(20);
     expect(tds[1].innerHTML).to.eql('101');         // term count
     expect(tds[3].innerHTML).to.eql('19');          // docs with terms
     expect(tds[5].innerHTML).to.eql('aardvark');    // min term
     expect(tds[7].innerHTML).to.eql('zebra');       // max term
 
+      const termTable = renderedDOM.children[2].children[0];
+      expect(termTable.tagName).to.eql('TABLE');
+
     // count the terms
-    const rows = renderedDOM.children[2].children;
+    const rows = termTable.children[1].children;
     expect(rows.length).to.eql(3);
   });
 


### PR DESCRIPTION
This tidies up the terms list a bit, and displays docFreq and totalTermFreq at the top terms level.  It requires a bit of tweaking to the endpoints:

- /terms now returns a List<TermData> instead of a List<String> for the terms, including docFreq and totalTermFreq
- TermData no longer includes postings
- /postings directly return an array of docids

This will probably require reworking how the postings lists are displayed again, as they're sort of squashed up now, but I think it looks nicer and presents the data more informatively.