### PR TITLE
Fix for issue 41

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,15 +121,23 @@ Return terms for <field>.
 #### `/postings/<field>/<term>`
   Optional query string parameters:
   - `segment`: (as above)
+  - `encoding`: encoding of <term>
   - `offset`: offset in the postings list from which to return postings
   - `count`: how many postings to return
 
 Return postings for <field> and <term>.
 
+#### `/positions/<field>/<term>/<docid>`
+  Optional query string parameters:
+  - `encoding`: encoding of <term>
+  - `segment`: (as above)
+
+Return positions for <field>, <term> and <docid>.
+
 #### `/docvalues/<field>`
   Optional query string parameters:
   - `segment`: (as above)
-  - `encoding`: (as above)
+  - `encoding`: encoding to return doc values in
   - `docs`: a list of doc IDs and/or ranges to return doc values for
 
 Return doc values ordered by doc ID for <field>.

--- a/src/main/java/com/github/flaxsearch/resources/PositionsResource.java
+++ b/src/main/java/com/github/flaxsearch/resources/PositionsResource.java
@@ -25,8 +25,10 @@ import java.util.Locale;
 import com.github.flaxsearch.api.DocTermData;
 import com.github.flaxsearch.api.PositionData;
 import com.github.flaxsearch.util.ReaderManager;
+import com.github.flaxsearch.util.BytesRefUtils;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.util.BytesRef;
 
 @Path("/positions/{field}/{term}/{docId}")
 @Produces(MediaType.APPLICATION_JSON)
@@ -42,9 +44,11 @@ public class PositionsResource {
     public DocTermData getDocTermData(@QueryParam("segment") Integer segment,
                                       @PathParam("field") String field,
                                       @PathParam("term") String term,
+                                      @QueryParam("encoding") String encoding,
                                       @PathParam("docId") int docId) throws Exception {
 
-        TermsEnum te = readerManager.findTermPostings(segment, field, term);
+    	BytesRef decodedTerm = encoding == null ? new BytesRef(term) : BytesRefUtils.decode(term, encoding);
+        TermsEnum te = readerManager.findTermPostings(segment, field, decodedTerm);
         PostingsEnum pe = te.postings(null, PostingsEnum.ALL);
 
         if (pe.advance(docId) != docId) {

--- a/src/main/java/com/github/flaxsearch/resources/PostingsResource.java
+++ b/src/main/java/com/github/flaxsearch/resources/PostingsResource.java
@@ -19,10 +19,12 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 
+import com.github.flaxsearch.util.BytesRefUtils;
 import com.github.flaxsearch.util.ReaderManager;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.BytesRef;
 
 @Path("/postings/{field}/{term}")
 @Produces(MediaType.APPLICATION_JSON)
@@ -38,10 +40,12 @@ public class PostingsResource {
     public int[] getPostings(@QueryParam("segment") Integer segment,
                                 @PathParam("field") String field,
                                 @PathParam("term") String term,
+                                @QueryParam("encoding") String encoding,
                                 @QueryParam("offset") @DefaultValue("0") int offset,
                                 @QueryParam("count") @DefaultValue("1000000") int count) throws IOException {
 
-        TermsEnum te = readerManager.findTermPostings(segment, field, term);
+    	BytesRef decodedTerm = encoding == null ? new BytesRef(term) : BytesRefUtils.decode(term, encoding);
+        TermsEnum te = readerManager.findTermPostings(segment, field, decodedTerm);
         Bits liveDocs = readerManager.getLiveDocs(segment);
         PostingsEnum pe = te.postings(null, PostingsEnum.NONE);
 

--- a/src/main/java/com/github/flaxsearch/util/ReaderManager.java
+++ b/src/main/java/com/github/flaxsearch/util/ReaderManager.java
@@ -90,7 +90,7 @@ public interface ReaderManager {
         return getLeafReader(segment).maxDoc();
     }
 
-    default TermsEnum findTermPostings(Integer segment, String field, String term) throws IOException {
+    default TermsEnum findTermPostings(Integer segment, String field, BytesRef term) throws IOException {
 
         Fields fields = getFields(segment);
         Terms terms = fields.terms(field);
@@ -103,7 +103,7 @@ public interface ReaderManager {
         TermsEnum te = terms.iterator();
 
         assert (term != null);
-        if (!te.seekExact(new BytesRef(term))) {
+        if (!te.seekExact(term)) {
             String msg = String.format("No term %s on field %s", term, field);
             throw new WebApplicationException(msg, Response.Status.NOT_FOUND);
         }

--- a/ui/src/components/postingitem.js
+++ b/ui/src/components/postingitem.js
@@ -23,7 +23,7 @@ class PostingItem extends React.Component {
       this.setState({ positionsData: undefined });
     }
     else {
-      loadPositions(p.segment, p.field, p.term, p.docid,
+      loadPositions(p.segment, p.field, p.term, p.encoding, p.docid,
         positionsData => this.setState({ positionsData }),
         errmsg => {
           if (errmsg.includes('No document')) {
@@ -84,7 +84,9 @@ PostingItem.propTypes = {
   ]),
   field: PropTypes.string.isRequired,
   term: PropTypes.string.isRequired,
-  docid: PropTypes.number.isRequired
+  encoding: PropTypes.string.isRequired,
+  docid: PropTypes.number.isRequired,
+  showAlert: PropTypes.func.isRequired
 }
 
 export default PostingItem;

--- a/ui/src/components/postings.js
+++ b/ui/src/components/postings.js
@@ -16,7 +16,7 @@ class Postings extends React.Component {
 
     componentDidMount() {
         const p = this.props;
-        loadPostings(p.segment, p.field, p.term, 0, FETCH_COUNT,
+        loadPostings(p.segment, p.field, p.term, p.encoding, 0, FETCH_COUNT,
             data => {
 	            this.setState(data);
 	        },
@@ -35,7 +35,7 @@ class Postings extends React.Component {
         const p = this.props;
         const s = this.state;
 
-        loadPostings(p.segment, p.field, p.term, s.moreFrom, FETCH_COUNT,
+        loadPostings(p.segment, p.field, p.term, p.encoding, s.moreFrom, FETCH_COUNT,
             data => {
                 this.setState({
                     postings: this.state.postings.concat(data.postings),
@@ -76,6 +76,16 @@ class Postings extends React.Component {
             {moreFromLink}
         </div>;
     }
+}
+
+Postings.propTypes = {
+  segment: PropTypes.oneOfType([
+    PropTypes.string, PropTypes.number
+  ]),
+  field: PropTypes.string.isRequired,
+  term: PropTypes.string.isRequired,
+  encoding: PropTypes.string.isRequired,
+  showAlert: PropTypes.func.isRequired
 }
 
 export default Postings;

--- a/ui/src/components/postings.js
+++ b/ui/src/components/postings.js
@@ -68,7 +68,8 @@ class Postings extends React.Component {
 
         const postingList = s.postings.map((docid, idx) =>
             <PostingItem key={idx} segment={p.segment} field={p.field}
-                term={p.term} docid={docid} showAlert={p.showAlert}/>
+                term={p.term} encoding={p.encoding} docid={docid}
+                showAlert={p.showAlert}/>
         );
         return <div>
             <div style={{ color: 'grey' }}>in docs:</div>

--- a/ui/src/components/termitem.js
+++ b/ui/src/components/termitem.js
@@ -33,7 +33,8 @@ class TermItem extends React.Component {
     const postings = s.displayPostings ?
       <div style={POSTINGSSTYLE}>
         <Postings segment={p.segment} field={p.field}
-         term={p.term} showAlert={p.showAlert} />
+         term={p.term} showAlert={p.showAlert}
+         encoding={p.encoding} />
       </div> : null;
 
     const toggle = s.displayPostings ?
@@ -57,7 +58,9 @@ TermItem.propTypes = {
     PropTypes.string, PropTypes.number
   ]),
   field: PropTypes.string.isRequired,
-  term: PropTypes.string.isRequired
+  term: PropTypes.string.isRequired,
+  encoding: PropTypes.string.isRequired,
+  showAlert: PropTypes.func.isRequired
 }
 
 export default TermItem;

--- a/ui/src/components/terms.js
+++ b/ui/src/components/terms.js
@@ -92,7 +92,10 @@ class Terms extends React.Component {
         const termEntries = s.termsData.terms.map((term, idx) => (
             <tr key={idx}>
                 <td>
-                    <TermItem key={idx} segment={p.segment} field={p.field} term={term.term} showAlert={p.showAlert}/>
+                    <TermItem key={idx}
+                     segment={p.segment} field={p.field}
+                     term={term.term} encoding={s.encoding}
+                     showAlert={p.showAlert} />
                 </td>
                 <td>{term.docFreq}</td>
                 <td>{term.totalTermFreq}</td>


### PR DESCRIPTION
Added encoding to postings and positions endpoints, which allows terms to be specified in the usual set of encodings (not just UTF8).