### PR TITLE
Passing a non-existent index path should throw an exception

### DIFF
--- a/src/main/java/com/github/flaxsearch/util/FSReaderManager.java
+++ b/src/main/java/com/github/flaxsearch/util/FSReaderManager.java
@@ -15,7 +15,10 @@ package com.github.flaxsearch.util;
  *   limitations under the License.
  */
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import io.dropwizard.lifecycle.Managed;
@@ -31,7 +34,10 @@ public class FSReaderManager implements ReaderManager, Managed {
     private final IndexReader reader;
 
     public FSReaderManager(String indexPath) throws IOException {
-        this.directory = FSDirectory.open(Paths.get(indexPath));
+        Path path = Paths.get(indexPath);
+        if (Files.exists(path) == false)
+            throw new FileNotFoundException("Path " + path + " does not exist");
+        this.directory = FSDirectory.open(path);
         this.reader = DirectoryReader.open(directory);
     }
 

--- a/src/test/java/com/github/flaxsearch/resources/TestFSReaderManager.java
+++ b/src/test/java/com/github/flaxsearch/resources/TestFSReaderManager.java
@@ -1,0 +1,34 @@
+package com.github.flaxsearch.resources;
+
+/*
+ *   Copyright (c) 2017 Lemur Consulting Ltd.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+import java.io.FileNotFoundException;
+
+import com.github.flaxsearch.util.FSReaderManager;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class TestFSReaderManager {
+
+    @Test
+    public void testThrowsFileNotFoundException() {
+        Assertions.assertThatThrownBy(() -> new FSReaderManager("/non/existant/path"))
+                .isInstanceOf(FileNotFoundException.class)
+                .hasMessageContaining("/non/existant/path");
+    }
+
+}


### PR DESCRIPTION
Currently, it creates the path and then bails because there's no index there
yet.