### PR TITLE
Updated to lucene 7.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@
     </build>
 
     <properties>
-        <dropwizard.version>1.0.0</dropwizard.version>
-        <lucene.version>6.4.0</lucene.version>
+        <dropwizard.version>1.0.9</dropwizard.version>
+        <lucene.version>7.0.1</lucene.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/com/github/flaxsearch/api/AnyDocValuesResponse.java
+++ b/src/main/java/com/github/flaxsearch/api/AnyDocValuesResponse.java
@@ -1,23 +1,23 @@
 package com.github.flaxsearch.api;
 
 public class AnyDocValuesResponse {
-	private String type;
-	private Object values;
+    private String type;
+    private Object values;
 
-	public AnyDocValuesResponse() {
-		// required for unit test
-	}
+    public AnyDocValuesResponse() {
+        // required for unit test
+    }
 
-	public AnyDocValuesResponse(String type, Object values) {
-		this.type = type;
-		this.values = values;
-	}
-	
-	public String getType() {
-		return type;
-	}
-	
-	public Object getValues() {
-		return values;
-	}
+    public AnyDocValuesResponse(String type, Object values) {
+        this.type = type;
+        this.values = values;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public Object getValues() {
+        return values;
+    }
 }

--- a/src/main/java/com/github/flaxsearch/api/DocumentData.java
+++ b/src/main/java/com/github/flaxsearch/api/DocumentData.java
@@ -26,35 +26,35 @@ public class DocumentData {
     public final boolean complete;
 
     public DocumentData() {
-    	fields = null;
-    	totalLengthInChars = 0;
-    	complete = false;
+        fields = null;
+        totalLengthInChars = 0;
+        complete = false;
     }
 
     public DocumentData(Document document, int maxFieldLength, int maxFields) {
-    	long length = 0;
-    	int fieldCount = 0;
-    	boolean complete = true;
-    	
+        long length = 0;
+        int fieldCount = 0;
+        boolean complete = true;
+
         ImmutableMultimap.Builder<String, String> builder = ImmutableMultimap.builder();
         for (IndexableField field : document) {
-        	String val = field.stringValue();
-        	if (val != null) {
-        		length += val.length();
-        		if (fieldCount < maxFields) {
-        			if (val.length() <= maxFieldLength) {
-            			builder.put(field.name(), val);         				
-        			}
-        			else {
-            			builder.put(field.name(), val.substring(0, maxFieldLength) + "...");
-        				complete = false;
-        			}
-        		}
-        		else {
-        			complete = false;
-        		}
-        	}
-        	fieldCount += 1;
+            String val = field.stringValue();
+            if (val != null) {
+                length += val.length();
+                if (fieldCount < maxFields) {
+                    if (val.length() <= maxFieldLength) {
+                        builder.put(field.name(), val);
+                    }
+                    else {
+                        builder.put(field.name(), val.substring(0, maxFieldLength) + "...");
+                        complete = false;
+                    }
+                }
+                else {
+                    complete = false;
+                }
+            }
+            fieldCount += 1;
         }
         this.fields = builder.build();
         this.totalLengthInChars = length;

--- a/src/main/java/com/github/flaxsearch/api/FieldData.java
+++ b/src/main/java/com/github/flaxsearch/api/FieldData.java
@@ -42,7 +42,7 @@ public class FieldData {
                      @JsonProperty("hasPayloads")  boolean hasPayloads,
                      @JsonProperty("docValuesType") DocValuesType docValuesType,
                      @JsonProperty("pointDimensionCount") int pointDimensionCount,
-    				 @JsonProperty("hasTerms") boolean hasTerms) {
+                     @JsonProperty("hasTerms") boolean hasTerms) {
         this.name = name;
         this.indexOptions = indexOptions;
         this.hasNorms = hasNorms;

--- a/src/main/java/com/github/flaxsearch/api/SegmentData.java
+++ b/src/main/java/com/github/flaxsearch/api/SegmentData.java
@@ -30,11 +30,11 @@ public class SegmentData {
         ord = ctx.ord;
         maxDoc = ctx.reader().maxDoc();
         numDocs = ctx.reader().numDocs();
-        if (ctx.reader().getIndexSort() == null) {
+        if (ctx.reader().getMetaData().getSort() == null) {
             sort = "none";
         }
         else {
-            sort = ctx.reader().getIndexSort().toString();
+            sort = ctx.reader().getMetaData().getSort().toString();
         }
     }
 

--- a/src/main/java/com/github/flaxsearch/api/ValueWithOrd.java
+++ b/src/main/java/com/github/flaxsearch/api/ValueWithOrd.java
@@ -17,19 +17,19 @@ package com.github.flaxsearch.api;
  */
 
 public class ValueWithOrd {
-	private String value;
-	private long ord;	
+    private String value;
+    private long ord;
 
-	public ValueWithOrd(String value, long ord) {
-		this.value = value;
-		this.ord = ord;
-	}
-	
-	public String getValue() {
-		return value;
-	}
-	
-	public long getOrd() {
-		return ord;
-	}
+    public ValueWithOrd(String value, long ord) {
+        this.value = value;
+        this.ord = ord;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public long getOrd() {
+        return ord;
+    }
 }

--- a/src/main/java/com/github/flaxsearch/resources/DocValuesResource.java
+++ b/src/main/java/com/github/flaxsearch/resources/DocValuesResource.java
@@ -57,7 +57,7 @@ public class DocValuesResource {
                                             @QueryParam("encoding") @DefaultValue("utf8") String encoding,
                                             @QueryParam("docs") String docs)
                                             throws IOException {
-    	AnyDocValuesResponse response = null;
+        AnyDocValuesResponse response = null;
         int maxDoc = readerManager.getMaxDoc(segment);
 
 
@@ -73,69 +73,69 @@ public class DocValuesResource {
 
         DocValuesType dvtype = fieldInfo.getDocValuesType();
         try {
-	        if (dvtype == DocValuesType.BINARY) {
-	        	// TODO: Sort docIds and use advanceExact
-	            BinaryDocValues dv = readerManager.getBinaryDocValues(segment, field);
-	            Map<Integer,String> values = new HashMap<>(sortedDocIds.size());
-	            for (int docid : sortedDocIds) {
-					if (!dv.advanceExact(docid)) continue;
-	                values.put(docid, BytesRefUtils.encode(dv.binaryValue(), encoding));
-	            }
-	            response = new AnyDocValuesResponse("BINARY", values);
-	        }
-	        else if (dvtype == DocValuesType.NUMERIC) {
-	            NumericDocValues dv = readerManager.getNumericDocValues(segment, field);
-	            Map<Integer,Long> values = new HashMap<>(sortedDocIds.size());
-	            for (int docid : sortedDocIds) {
-					if (!dv.advanceExact(docid)) continue;
+            if (dvtype == DocValuesType.BINARY) {
+                // TODO: Sort docIds and use advanceExact
+                BinaryDocValues dv = readerManager.getBinaryDocValues(segment, field);
+                Map<Integer,String> values = new HashMap<>(sortedDocIds.size());
+                for (int docid : sortedDocIds) {
+                    if (!dv.advanceExact(docid)) continue;
+                    values.put(docid, BytesRefUtils.encode(dv.binaryValue(), encoding));
+                }
+                response = new AnyDocValuesResponse("BINARY", values);
+            }
+            else if (dvtype == DocValuesType.NUMERIC) {
+                NumericDocValues dv = readerManager.getNumericDocValues(segment, field);
+                Map<Integer,Long> values = new HashMap<>(sortedDocIds.size());
+                for (int docid : sortedDocIds) {
+                    if (!dv.advanceExact(docid)) continue;
 
-					values.put(docid, dv.longValue());
-	            }
-	            response = new AnyDocValuesResponse("NUMERIC", values);
-	        }
-	        else if (dvtype == DocValuesType.SORTED_NUMERIC) {
-	            SortedNumericDocValues dv = readerManager.getSortedNumericDocValues(segment, field);
-	            Map<Integer,List<Long>> values = new HashMap<>(sortedDocIds.size());
-	            for (int docid : sortedDocIds) {
-	            	if (!dv.advanceExact(docid)) continue;
+                    values.put(docid, dv.longValue());
+                }
+                response = new AnyDocValuesResponse("NUMERIC", values);
+            }
+            else if (dvtype == DocValuesType.SORTED_NUMERIC) {
+                SortedNumericDocValues dv = readerManager.getSortedNumericDocValues(segment, field);
+                Map<Integer,List<Long>> values = new HashMap<>(sortedDocIds.size());
+                for (int docid : sortedDocIds) {
+                    if (!dv.advanceExact(docid)) continue;
 
-					int count = dv.docValueCount();
-					List<Long> perDocValues = new ArrayList<>(count);
-	                for (int index = 0; index < count; ++index) {
-						perDocValues.add(dv.nextValue());
-	                }
-	                values.put(docid, perDocValues);
-	            }
-	            response = new AnyDocValuesResponse("SORTED_NUMERIC", values);
-	        }
-	        else if (dvtype == DocValuesType.SORTED) {
-	            SortedDocValues dv = readerManager.getSortedDocValues(segment, field);
-	            Map<Integer,ValueWithOrd> values = new HashMap<>(sortedDocIds.size());
-	            for (int docid : sortedDocIds) {
-					if (!dv.advanceExact(docid)) continue;
-	                values.put(docid, new ValueWithOrd(BytesRefUtils.encode(dv.binaryValue(), encoding), dv.ordValue()));
-	            }
-	            response = new AnyDocValuesResponse("SORTED", values);
-	        }
-	        else if (dvtype == DocValuesType.SORTED_SET) {
-	            SortedSetDocValues dv = readerManager.getSortedSetDocValues(segment, field);
-	            Map<Integer,List<ValueWithOrd>> values = new HashMap<>(sortedDocIds.size());
-	            for (int docid : sortedDocIds) {
-					if (!dv.advanceExact(docid)) continue;
+                    int count = dv.docValueCount();
+                    List<Long> perDocValues = new ArrayList<>(count);
+                    for (int index = 0; index < count; ++index) {
+                        perDocValues.add(dv.nextValue());
+                    }
+                    values.put(docid, perDocValues);
+                }
+                response = new AnyDocValuesResponse("SORTED_NUMERIC", values);
+            }
+            else if (dvtype == DocValuesType.SORTED) {
+                SortedDocValues dv = readerManager.getSortedDocValues(segment, field);
+                Map<Integer,ValueWithOrd> values = new HashMap<>(sortedDocIds.size());
+                for (int docid : sortedDocIds) {
+                    if (!dv.advanceExact(docid)) continue;
+                    values.put(docid, new ValueWithOrd(BytesRefUtils.encode(dv.binaryValue(), encoding), dv.ordValue()));
+                }
+                response = new AnyDocValuesResponse("SORTED", values);
+            }
+            else if (dvtype == DocValuesType.SORTED_SET) {
+                SortedSetDocValues dv = readerManager.getSortedSetDocValues(segment, field);
+                Map<Integer,List<ValueWithOrd>> values = new HashMap<>(sortedDocIds.size());
+                for (int docid : sortedDocIds) {
+                    if (!dv.advanceExact(docid)) continue;
 
-	                List<ValueWithOrd> perDocValues = new ArrayList<>((int)dv.getValueCount());
-	                long ord;
-	                while ((ord = dv.nextOrd()) != SortedSetDocValues.NO_MORE_ORDS) {
-	                     perDocValues.add(new ValueWithOrd(BytesRefUtils.encode(dv.lookupOrd(ord), encoding), ord));
-	                }
-	                values.put(docid, perDocValues);
-	            }
-	            response = new AnyDocValuesResponse("SORTED_SET", values);
-	        }
-	        else {
-	            String msg = String.format("No doc values for field %s", field);
-	            throw new WebApplicationException(msg, Response.Status.NOT_FOUND);
-	        }
+                    List<ValueWithOrd> perDocValues = new ArrayList<>((int)dv.getValueCount());
+                    long ord;
+                    while ((ord = dv.nextOrd()) != SortedSetDocValues.NO_MORE_ORDS) {
+                         perDocValues.add(new ValueWithOrd(BytesRefUtils.encode(dv.lookupOrd(ord), encoding), ord));
+                    }
+                    values.put(docid, perDocValues);
+                }
+                response = new AnyDocValuesResponse("SORTED_SET", values);
+            }
+            else {
+                String msg = String.format("No doc values for field %s", field);
+                throw new WebApplicationException(msg, Response.Status.NOT_FOUND);
+            }
         }
         catch (NumberFormatException e) {
             throw new WebApplicationException("Field " + field + " cannot be decoded as " + encoding, Response.Status.BAD_REQUEST);
@@ -147,23 +147,23 @@ public class DocValuesResource {
     @Path("/ordered")
     @GET
     public AnyDocValuesResponse getOrderedDocValues(@QueryParam("segment") Integer segment,
-            										@PathParam("field") String field,
-            										@QueryParam("from") String startTerm,
-            										@QueryParam("offset") Integer offset,
-            										@QueryParam("count") @DefaultValue("50") int count,
-            										@QueryParam("filter") String filter,
-            										@QueryParam("encoding") @DefaultValue("utf8") String encoding) 
-    												throws IOException {
+                                                    @PathParam("field") String field,
+                                                    @QueryParam("from") String startTerm,
+                                                    @QueryParam("offset") Integer offset,
+                                                    @QueryParam("count") @DefaultValue("50") int count,
+                                                    @QueryParam("filter") String filter,
+                                                    @QueryParam("encoding") @DefaultValue("utf8") String encoding)
+                                                    throws IOException {
 
-    	if (startTerm != null) {
-        	if (offset != null) {
-        		throw new WebApplicationException("Cannot have both 'from' and 'offset' parameters", Response.Status.FORBIDDEN);
-        	}
-        	if (filter != null) {
-        		throw new WebApplicationException("Cannot have both 'from' and 'filter' parameters", Response.Status.FORBIDDEN);        		
-        	}
-    	}
-    	
+        if (startTerm != null) {
+            if (offset != null) {
+                throw new WebApplicationException("Cannot have both 'from' and 'offset' parameters", Response.Status.FORBIDDEN);
+            }
+            if (filter != null) {
+                throw new WebApplicationException("Cannot have both 'from' and 'filter' parameters", Response.Status.FORBIDDEN);
+            }
+        }
+
         FieldInfo fieldInfo = readerManager.getFieldInfo(segment, field);
 
         if (fieldInfo == null) {
@@ -177,31 +177,31 @@ public class DocValuesResource {
             TermsEnum te;
 
             if (dvtype == DocValuesType.SORTED) {
-            	if (filter != null && filter.length() > 0) {
-    	            te = readerManager.getSortedDocValues(segment, field).intersect(
-    	            		new CompiledAutomaton(new RegExp(filter).toAutomaton()));
-            		
-            	} 
-            	else {
-            		te = readerManager.getSortedDocValues(segment, field).termsEnum();
-            	}
-	            type_s = "SORTED";
-	        }
-	        else if (dvtype == DocValuesType.SORTED_SET) {
-            	if (filter != null && filter.length() > 0) {
-            		te = readerManager.getSortedSetDocValues(segment, field).intersect(
-    	            		new CompiledAutomaton(new RegExp(filter).toAutomaton()));
-            	}
-            	else {
-            		te = readerManager.getSortedSetDocValues(segment, field).termsEnum();
-            	}
-	            type_s = "SORTED_SET";
-	        }
-	        else {
-	        	throw new WebApplicationException("Field " + field + " cannot be viewed in value order", Response.Status.BAD_REQUEST);
-	        }
+                if (filter != null && filter.length() > 0) {
+                    te = readerManager.getSortedDocValues(segment, field).intersect(
+                            new CompiledAutomaton(new RegExp(filter).toAutomaton()));
+
+                }
+                else {
+                    te = readerManager.getSortedDocValues(segment, field).termsEnum();
+                }
+                type_s = "SORTED";
+            }
+            else if (dvtype == DocValuesType.SORTED_SET) {
+                if (filter != null && filter.length() > 0) {
+                    te = readerManager.getSortedSetDocValues(segment, field).intersect(
+                            new CompiledAutomaton(new RegExp(filter).toAutomaton()));
+                }
+                else {
+                    te = readerManager.getSortedSetDocValues(segment, field).termsEnum();
+                }
+                type_s = "SORTED_SET";
+            }
+            else {
+                throw new WebApplicationException("Field " + field + " cannot be viewed in value order", Response.Status.BAD_REQUEST);
+            }
             
-	        List<ValueWithOrd> collected = new ArrayList<>();
+            List<ValueWithOrd> collected = new ArrayList<>();
 
             if (startTerm != null) {
                 BytesRef start = BytesRefUtils.decode(startTerm, encoding);
@@ -215,26 +215,26 @@ public class DocValuesResource {
 
             boolean hasMore = true;
             if (offset != null) {
-            	for (int i = 0; i < offset; i++) {
-            		if (te.next() == null) {
-            			hasMore = false;
-            			break;
-            		}
-            	}
+                for (int i = 0; i < offset; i++) {
+                    if (te.next() == null) {
+                        hasMore = false;
+                        break;
+                    }
+                }
             }
 
             if (hasMore) {
-            	do {
-            		collected.add(new ValueWithOrd(BytesRefUtils.encode(te.term(), encoding), te.ord()));
-            	}
-            	while (te.next() != null && --count > 0);
+                do {
+                    collected.add(new ValueWithOrd(BytesRefUtils.encode(te.term(), encoding), te.ord()));
+                }
+                while (te.next() != null && --count > 0);
             }
             
             return new AnyDocValuesResponse(type_s, collected);
         }
-	    catch (NumberFormatException e) {
-	        throw new WebApplicationException("Field " + field + " cannot be decoded as " + encoding, Response.Status.BAD_REQUEST);
-	    }    	
+        catch (NumberFormatException e) {
+            throw new WebApplicationException("Field " + field + " cannot be decoded as " + encoding, Response.Status.BAD_REQUEST);
+        }
     }
     
     @Path("/binary")
@@ -253,7 +253,7 @@ public class DocValuesResource {
         }
 
         for (int i = 0; i < count && i < maxDoc; i++) {
-        	if (!dv.advanceExact(fromDoc + i)) continue;
+            if (!dv.advanceExact(fromDoc + i)) continue;
             values.add(dv.binaryValue().utf8ToString());
         }
 
@@ -276,7 +276,7 @@ public class DocValuesResource {
         }
 
         for (int i = 0; i < count && i < maxDoc; i++) {
-        	if (!dv.advanceExact(fromDoc + i)) continue;
+            if (!dv.advanceExact(fromDoc + i)) continue;
             values.add(Long.toString(dv.longValue()));
         }
 
@@ -326,7 +326,7 @@ public class DocValuesResource {
         }
 
         for (int i = 0; i < count && i < maxDoc; i++) {
-        	if (!dv.advanceExact(fromDoc + i)) continue;
+            if (!dv.advanceExact(fromDoc + i)) continue;
             values.add(dv.binaryValue().utf8ToString());
         }
 
@@ -349,7 +349,7 @@ public class DocValuesResource {
         }
 
         for (int i = 0; i < count && i < maxDoc; i++) {
-        	if (!dv.advanceExact(fromDoc +i)) continue;
+            if (!dv.advanceExact(fromDoc +i)) continue;
             List<String> perDocValues = new ArrayList<>((int)dv.getValueCount());
             long ord;
             while ((ord = dv.nextOrd()) != SortedSetDocValues.NO_MORE_ORDS) {
@@ -362,58 +362,58 @@ public class DocValuesResource {
     }
     
     public static Set<Integer> parseDocSet(String docs, int maxDoc) {
-    	Set<Integer> docset = new HashSet<>();
-    	
-    	if (docs == null) {
-    		// return default set
-    		for (int i = 0; i < 100 && i < maxDoc; i++) {
-    			docset.add(i);
-    		}
-    	}
-    	else {
-	    	for (String chunk : docs.split(",")) {
-	    		chunk = chunk.trim();
-	    		if (chunk.contains("-")) {
-	    			String[] range_s = chunk.split("-");
-	    			if (range_s.length == 1) {
-    					// handle "n-" gracefully
-	    				int num = Integer.parseInt(range_s[0]);
-	    				if (num < maxDoc) docset.add(num);
-	    			}
-	    			else if (range_s.length == 2) {
-		    			try {
-			    			int range_from = Integer.parseInt(range_s[0]);
-			    			if (range_from < maxDoc) {
-			    				if (range_s[1].equals("")) {
-			    					// handle "n-" gracefully
-			    					docset.add(range_from);
-			    				}
-			    				else {
-			    					int range_to = Math.min(Integer.parseInt(range_s[1]), maxDoc - 1);
-			    					if (range_from <= range_to) {
-			    						for (int i = range_from; i <= range_to; i++) {
-			    							docset.add(i);
-			    						}
-					    			}
-			    				}
-			    			}
-		    			} 
-		    			catch (NumberFormatException e) { }
-	    			}
-	    			else if (range_s.length > 2) {
-	    				String msg = String.format("Incorrect range format \"%s\" in docs", chunk);
-	    	            throw new WebApplicationException(msg, Response.Status.BAD_REQUEST);
-	    			}
-	    		}
-	    		else {
-	    			try {
-	    				int num = Integer.parseInt(chunk);
-	    				if (num < maxDoc) docset.add(num);
-	    			} 
-	    			catch (NumberFormatException e) { }
-	    		}
-	    	}
-    	}
-    	return docset;
+        Set<Integer> docset = new HashSet<>();
+
+        if (docs == null) {
+            // return default set
+            for (int i = 0; i < 100 && i < maxDoc; i++) {
+                docset.add(i);
+            }
+        }
+        else {
+            for (String chunk : docs.split(",")) {
+                chunk = chunk.trim();
+                if (chunk.contains("-")) {
+                    String[] range_s = chunk.split("-");
+                    if (range_s.length == 1) {
+                        // handle "n-" gracefully
+                        int num = Integer.parseInt(range_s[0]);
+                        if (num < maxDoc) docset.add(num);
+                    }
+                    else if (range_s.length == 2) {
+                        try {
+                            int range_from = Integer.parseInt(range_s[0]);
+                            if (range_from < maxDoc) {
+                                if (range_s[1].equals("")) {
+                                    // handle "n-" gracefully
+                                    docset.add(range_from);
+                                }
+                                else {
+                                    int range_to = Math.min(Integer.parseInt(range_s[1]), maxDoc - 1);
+                                    if (range_from <= range_to) {
+                                        for (int i = range_from; i <= range_to; i++) {
+                                            docset.add(i);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        catch (NumberFormatException e) { }
+                    }
+                    else if (range_s.length > 2) {
+                        String msg = String.format("Incorrect range format \"%s\" in docs", chunk);
+                        throw new WebApplicationException(msg, Response.Status.BAD_REQUEST);
+                    }
+                }
+                else {
+                    try {
+                        int num = Integer.parseInt(chunk);
+                        if (num < maxDoc) docset.add(num);
+                    }
+                    catch (NumberFormatException e) { }
+                }
+            }
+        }
+        return docset;
     }
 }

--- a/src/main/java/com/github/flaxsearch/resources/DocumentResource.java
+++ b/src/main/java/com/github/flaxsearch/resources/DocumentResource.java
@@ -37,17 +37,17 @@ public class DocumentResource {
 
     @GET
     public DocumentData getDocument(@QueryParam("segment") Integer segment, 
-    								@PathParam("docId") int doc,
-    								@QueryParam("maxFieldLength") @DefaultValue("2147483647") int maxFieldLength,
-    								@QueryParam("maxFields") @DefaultValue("2147483647") int maxFields) throws IOException 
+                                    @PathParam("docId") int doc,
+                                    @QueryParam("maxFieldLength") @DefaultValue("2147483647") int maxFieldLength,
+                                    @QueryParam("maxFields") @DefaultValue("2147483647") int maxFields) throws IOException
     {
         IndexReader reader = segment == null ? readerManager.getIndexReader() : readerManager.getLeafReader(segment);
-    	if (doc < 0 || doc > reader.maxDoc()) {
-    		throw new WebApplicationException("Unknown document " + doc, Response.Status.NOT_FOUND);
-    	}
+        if (doc < 0 || doc > reader.maxDoc()) {
+            throw new WebApplicationException("Unknown document " + doc, Response.Status.NOT_FOUND);
+        }
 
-    	Document document = reader.document(doc);
-    	return new DocumentData(document, maxFieldLength, maxFields);
+        Document document = reader.document(doc);
+        return new DocumentData(document, maxFieldLength, maxFields);
     }
 
 }

--- a/src/main/java/com/github/flaxsearch/resources/FieldsResource.java
+++ b/src/main/java/com/github/flaxsearch/resources/FieldsResource.java
@@ -44,11 +44,8 @@ public class FieldsResource {
 
         List<FieldData> fieldData = new ArrayList<>();
         FieldInfos fieldInfos = readerManager.getFieldInfos(segment);
-
-        Fields fields = readerManager.getFields(segment);
-
         for (FieldInfo fieldInfo : fieldInfos) {
-            Terms terms = fields.terms(fieldInfo.name);
+            Terms terms = readerManager.getTerms(segment, fieldInfo.name);
             fieldData.add(new FieldData(fieldInfo, (terms != null)));
         }
 
@@ -59,10 +56,8 @@ public class FieldsResource {
     @GET
     @Path("{field}")
     public FieldData getField(@QueryParam("segment") Integer segment, @PathParam("field") String field) throws IOException {
-        FieldInfos fieldInfos = readerManager.getFieldInfos(segment);
-        Fields fields = readerManager.getFields(segment);
-        FieldInfo info = fieldInfos.fieldInfo(field);
-        Terms terms = fields.terms(info.name);
+        FieldInfo info = readerManager.getFieldInfo(segment, field);
+        Terms terms = readerManager.getTerms(segment, field);
         return new FieldData(info, terms != null);
     }
 

--- a/src/main/java/com/github/flaxsearch/resources/PointsResource.java
+++ b/src/main/java/com/github/flaxsearch/resources/PointsResource.java
@@ -45,46 +45,46 @@ public class PointsResource {
         }
 
         try {
-	        LeafReader reader = readerManager.getLeafReader(segment);
-	        PointValues points = reader.getPointValues(field);
-	
-	        final int numDims = points.getNumDimensions();
-	        final int bytesPerDim = points.getBytesPerDimension();
+            LeafReader reader = readerManager.getLeafReader(segment);
+            PointValues points = reader.getPointValues(field);
 
-	        // use array to allow assignment in anonymous object below
+            final int numDims = points.getNumDimensions();
+            final int bytesPerDim = points.getBytesPerDimension();
+
+            // use array to allow assignment in anonymous object below
             BKDNode[] currentNode = new BKDNode[1];
 
-	        points.intersect(new PointValues.IntersectVisitor() {
-	            @Override
-	            public void visit(int docID) throws IOException {
-	
-	            }
-	
-	            @Override
-	            public void visit(int docID, byte[] packedValue) throws IOException {
-	                currentNode[0].addDoc(docID, packedValue);
-	            }
-	
-	            @Override
-	            public PointValues.Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
-	                BKDNode node = new BKDNode(minPackedValue, maxPackedValue);
-	                if (currentNode[0] == null) {
-	                    currentNode[0] = node;
-	                }
-	                else {
+            points.intersect(new PointValues.IntersectVisitor() {
+                @Override
+                public void visit(int docID) throws IOException {
+
+                }
+
+                @Override
+                public void visit(int docID, byte[] packedValue) throws IOException {
+                    currentNode[0].addDoc(docID, packedValue);
+                }
+
+                @Override
+                public PointValues.Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
+                    BKDNode node = new BKDNode(minPackedValue, maxPackedValue);
+                    if (currentNode[0] == null) {
+                        currentNode[0] = node;
+                    }
+                    else {
                         BKDNode parent = currentNode[0].findParentOf(node, numDims, bytesPerDim);
-	                    node.setParent(parent);
-	                    currentNode[0] = node;
-	                }
-	                return PointValues.Relation.CELL_CROSSES_QUERY;
-	            }
-	
-	        });
-	
-	        return new PointsData(numDims, bytesPerDim, BKDNode.findRoot(currentNode[0]));
+                        node.setParent(parent);
+                        currentNode[0] = node;
+                    }
+                    return PointValues.Relation.CELL_CROSSES_QUERY;
+                }
+
+            });
+
+            return new PointsData(numDims, bytesPerDim, BKDNode.findRoot(currentNode[0]));
         }
         catch (IllegalArgumentException e) {
-        	String msg = String.format("No points data for field %s", field);
+            String msg = String.format("No points data for field %s", field);
             throw new WebApplicationException(msg, Response.Status.NOT_FOUND);
         }
     }

--- a/src/main/java/com/github/flaxsearch/resources/PointsResource.java
+++ b/src/main/java/com/github/flaxsearch/resources/PointsResource.java
@@ -46,15 +46,15 @@ public class PointsResource {
 
         try {
 	        LeafReader reader = readerManager.getLeafReader(segment);
-	        PointValues points = reader.getPointValues();
+	        PointValues points = reader.getPointValues(field);
 	
-	        final int numDims = points.getNumDimensions(field);
-	        final int bytesPerDim = points.getBytesPerDimension(field);
+	        final int numDims = points.getNumDimensions();
+	        final int bytesPerDim = points.getBytesPerDimension();
 
 	        // use array to allow assignment in anonymous object below
             BKDNode[] currentNode = new BKDNode[1];
 
-	        points.intersect(field, new PointValues.IntersectVisitor() {
+	        points.intersect(new PointValues.IntersectVisitor() {
 	            @Override
 	            public void visit(int docID) throws IOException {
 	

--- a/src/main/java/com/github/flaxsearch/resources/PositionsResource.java
+++ b/src/main/java/com/github/flaxsearch/resources/PositionsResource.java
@@ -47,7 +47,7 @@ public class PositionsResource {
                                       @QueryParam("encoding") String encoding,
                                       @PathParam("docId") int docId) throws Exception {
 
-    	BytesRef decodedTerm = encoding == null ? new BytesRef(term) : BytesRefUtils.decode(term, encoding);
+        BytesRef decodedTerm = encoding == null ? new BytesRef(term) : BytesRefUtils.decode(term, encoding);
         TermsEnum te = readerManager.findTermPostings(segment, field, decodedTerm);
         PostingsEnum pe = te.postings(null, PostingsEnum.ALL);
 

--- a/src/main/java/com/github/flaxsearch/resources/PostingsResource.java
+++ b/src/main/java/com/github/flaxsearch/resources/PostingsResource.java
@@ -44,7 +44,7 @@ public class PostingsResource {
                                 @QueryParam("offset") @DefaultValue("0") int offset,
                                 @QueryParam("count") @DefaultValue("1000000") int count) throws IOException {
 
-    	BytesRef decodedTerm = encoding == null ? new BytesRef(term) : BytesRefUtils.decode(term, encoding);
+        BytesRef decodedTerm = encoding == null ? new BytesRef(term) : BytesRefUtils.decode(term, encoding);
         TermsEnum te = readerManager.findTermPostings(segment, field, decodedTerm);
         Bits liveDocs = readerManager.getLiveDocs(segment);
         PostingsEnum pe = te.postings(null, PostingsEnum.NONE);
@@ -53,7 +53,7 @@ public class PostingsResource {
 
         int size = ((docFreq - offset) < count) ? (docFreq - offset) : count;
         if (size < 1) {
-        	return new int[0];
+            return new int[0];
         }
         
         int[] postings = new int[size];
@@ -62,7 +62,7 @@ public class PostingsResource {
         while ((docId = pe.nextDoc()) != PostingsEnum.NO_MORE_DOCS && i < (offset + count)) {
             if (liveDocs != null && liveDocs.get(docId) == false) continue;
             if (i >= offset) {
-            	postings[i - offset] = docId;
+                postings[i - offset] = docId;
             }
             i++;
         }

--- a/src/main/java/com/github/flaxsearch/resources/TermsResource.java
+++ b/src/main/java/com/github/flaxsearch/resources/TermsResource.java
@@ -53,9 +53,7 @@ public class TermsResource {
                                  @QueryParam("count") @DefaultValue("50") int count) throws IOException {
 
         try {
-            Fields fields = readerManager.getFields(segment);
-            Terms terms = fields.terms(field);
-
+            Terms terms = readerManager.getTerms(segment, field);
             if (terms == null)
                 throw new WebApplicationException("No such field " + field, Response.Status.NOT_FOUND);
 

--- a/src/main/java/com/github/flaxsearch/resources/TermsResource.java
+++ b/src/main/java/com/github/flaxsearch/resources/TermsResource.java
@@ -61,7 +61,7 @@ public class TermsResource {
             List<TermData> collected = new ArrayList<>();
 
             if (startTerm != null) {
-            	while(true) {
+                while(true) {
                     if (te.next() == null) {
                         return new TermsData(terms, Collections.emptyList(), encoding);
                     }

--- a/src/main/java/com/github/flaxsearch/util/BytesRefUtils.java
+++ b/src/main/java/com/github/flaxsearch/util/BytesRefUtils.java
@@ -23,7 +23,7 @@ import java.util.function.Function;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
-import org.apache.lucene.util.LegacyNumericUtils;
+import org.apache.solr.legacy.LegacyNumericUtils;
 import org.apache.lucene.util.NumericUtils;
 
 public class BytesRefUtils {

--- a/src/main/java/com/github/flaxsearch/util/BytesRefUtils.java
+++ b/src/main/java/com/github/flaxsearch/util/BytesRefUtils.java
@@ -77,8 +77,8 @@ public class BytesRefUtils {
         switch (type.toLowerCase(Locale.ROOT)) {
             case "base64" :
                 return b -> {
-                	BytesRef b2 = BytesRef.deepCopyOf(b);
-                	return new String(Base64.getUrlEncoder().encode(b2.bytes), Charset.defaultCharset());
+                    BytesRef b2 = BytesRef.deepCopyOf(b);
+                    return new String(Base64.getUrlEncoder().encode(b2.bytes), Charset.defaultCharset());
                 };
             case "utf8" :
                 return BytesRef::utf8ToString;

--- a/src/main/java/com/github/flaxsearch/util/ReaderManager.java
+++ b/src/main/java/com/github/flaxsearch/util/ReaderManager.java
@@ -27,10 +27,10 @@ public interface ReaderManager {
 
     IndexReader getIndexReader();
 
-    default Fields getFields(Integer segment) throws IOException {
+    default Terms getTerms(Integer segment, String field) throws IOException {
         if (segment == null)
-            return MultiFields.getFields(getIndexReader());
-        return getLeafReader(segment).fields();
+            return MultiFields.getFields(getIndexReader()).terms(field);
+        return getLeafReader(segment).terms(field);
     }
 
     default FieldInfos getFieldInfos(Integer segment) throws IOException {
@@ -92,8 +92,7 @@ public interface ReaderManager {
 
     default TermsEnum findTermPostings(Integer segment, String field, BytesRef term) throws IOException {
 
-        Fields fields = getFields(segment);
-        Terms terms = fields.terms(field);
+        Terms terms = getTerms(segment, field);
 
         if (terms == null) {
             String msg = String.format("No field %s", field);

--- a/src/main/java/org/apache/solr/legacy/LegacyNumericUtils.java
+++ b/src/main/java/org/apache/solr/legacy/LegacyNumericUtils.java
@@ -1,0 +1,510 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.legacy;
+
+
+import java.io.IOException;
+
+import org.apache.lucene.index.FilterLeafReader;
+import org.apache.lucene.index.FilteredTermsEnum;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
+
+/**
+ * This is a helper class to generate prefix-encoded representations for numerical values
+ * and supplies converters to represent float/double values as sortable integers/longs.
+ *
+ * <p>To quickly execute range queries in Apache Lucene, a range is divided recursively
+ * into multiple intervals for searching: The center of the range is searched only with
+ * the lowest possible precision in the trie, while the boundaries are matched
+ * more exactly. This reduces the number of terms dramatically.
+ *
+ * <p>This class generates terms to achieve this: First the numerical integer values need to
+ * be converted to bytes. For that integer values (32 bit or 64 bit) are made unsigned
+ * and the bits are converted to ASCII chars with each 7 bit. The resulting byte[] is
+ * sortable like the original integer value (even using UTF-8 sort order). Each value is also
+ * prefixed (in the first char) by the <code>shift</code> value (number of bits removed) used
+ * during encoding.
+ *
+ * <p>For easy usage, the trie algorithm is implemented for indexing inside
+ * {@link org.apache.solr.legacy.LegacyNumericTokenStream} that can index <code>int</code>, <code>long</code>,
+ * <code>float</code>, and <code>double</code>. For querying,
+ * {@link org.apache.solr.legacy.LegacyNumericRangeQuery} implements the query part
+ * for the same data types.
+ *
+ * @lucene.internal
+ *
+ * @deprecated Please use {@link org.apache.lucene.index.PointValues} instead.
+ *
+ * @since 2.9, API changed non backwards-compliant in 4.0
+ */
+
+@Deprecated
+public final class LegacyNumericUtils {
+
+    private LegacyNumericUtils() {} // no instance!
+
+    /**
+     * The default precision step used by {@link org.apache.solr.legacy.LegacyLongField},
+     * {@link org.apache.solr.legacy.LegacyDoubleField}, {@link org.apache.solr.legacy.LegacyNumericTokenStream}, {@link
+     * org.apache.solr.legacy.LegacyNumericRangeQuery}.
+     */
+    public static final int PRECISION_STEP_DEFAULT = 16;
+
+    /**
+     * The default precision step used by {@link org.apache.solr.legacy.LegacyIntField} and
+     * {@link org.apache.solr.legacy.LegacyFloatField}.
+     */
+    public static final int PRECISION_STEP_DEFAULT_32 = 8;
+
+    /**
+     * Longs are stored at lower precision by shifting off lower bits. The shift count is
+     * stored as <code>SHIFT_START_LONG+shift</code> in the first byte
+     */
+    public static final byte SHIFT_START_LONG = 0x20;
+
+    /**
+     * The maximum term length (used for <code>byte[]</code> buffer size)
+     * for encoding <code>long</code> values.
+     * @see #longToPrefixCoded
+     */
+    public static final int BUF_SIZE_LONG = 63/7 + 2;
+
+    /**
+     * Integers are stored at lower precision by shifting off lower bits. The shift count is
+     * stored as <code>SHIFT_START_INT+shift</code> in the first byte
+     */
+    public static final byte SHIFT_START_INT  = 0x60;
+
+    /**
+     * The maximum term length (used for <code>byte[]</code> buffer size)
+     * for encoding <code>int</code> values.
+     * @see #intToPrefixCoded
+     */
+    public static final int BUF_SIZE_INT = 31/7 + 2;
+
+    /**
+     * Returns prefix coded bits after reducing the precision by <code>shift</code> bits.
+     * This is method is used by {@link org.apache.solr.legacy.LegacyNumericTokenStream}.
+     * After encoding, {@code bytes.offset} will always be 0.
+     * @param val the numeric value
+     * @param shift how many bits to strip from the right
+     * @param bytes will contain the encoded value
+     */
+    public static void longToPrefixCoded(final long val, final int shift, final BytesRefBuilder bytes) {
+        // ensure shift is 0..63
+        if ((shift & ~0x3f) != 0) {
+            throw new IllegalArgumentException("Illegal shift value, must be 0..63; got shift=" + shift);
+        }
+        int nChars = (((63-shift)*37)>>8) + 1;    // i/7 is the same as (i*37)>>8 for i in 0..63
+        bytes.setLength(nChars+1);   // one extra for the byte that contains the shift info
+        bytes.grow(BUF_SIZE_LONG);
+        bytes.setByteAt(0, (byte)(SHIFT_START_LONG + shift));
+        long sortableBits = val ^ 0x8000000000000000L;
+        sortableBits >>>= shift;
+        while (nChars > 0) {
+            // Store 7 bits per byte for compatibility
+            // with UTF-8 encoding of terms
+            bytes.setByteAt(nChars--, (byte)(sortableBits & 0x7f));
+            sortableBits >>>= 7;
+        }
+    }
+
+    /**
+     * Returns prefix coded bits after reducing the precision by <code>shift</code> bits.
+     * This is method is used by {@link org.apache.solr.legacy.LegacyNumericTokenStream}.
+     * After encoding, {@code bytes.offset} will always be 0.
+     * @param val the numeric value
+     * @param shift how many bits to strip from the right
+     * @param bytes will contain the encoded value
+     */
+    public static void intToPrefixCoded(final int val, final int shift, final BytesRefBuilder bytes) {
+        // ensure shift is 0..31
+        if ((shift & ~0x1f) != 0) {
+            throw new IllegalArgumentException("Illegal shift value, must be 0..31; got shift=" + shift);
+        }
+        int nChars = (((31-shift)*37)>>8) + 1;    // i/7 is the same as (i*37)>>8 for i in 0..63
+        bytes.setLength(nChars+1);   // one extra for the byte that contains the shift info
+        bytes.grow(LegacyNumericUtils.BUF_SIZE_LONG);  // use the max
+        bytes.setByteAt(0, (byte)(SHIFT_START_INT + shift));
+        int sortableBits = val ^ 0x80000000;
+        sortableBits >>>= shift;
+        while (nChars > 0) {
+            // Store 7 bits per byte for compatibility
+            // with UTF-8 encoding of terms
+            bytes.setByteAt(nChars--, (byte)(sortableBits & 0x7f));
+            sortableBits >>>= 7;
+        }
+    }
+
+
+    /**
+     * Returns the shift value from a prefix encoded {@code long}.
+     * @throws NumberFormatException if the supplied {@link BytesRef} is
+     * not correctly prefix encoded.
+     */
+    public static int getPrefixCodedLongShift(final BytesRef val) {
+        final int shift = val.bytes[val.offset] - SHIFT_START_LONG;
+        if (shift > 63 || shift < 0)
+            throw new NumberFormatException("Invalid shift value (" + shift + ") in prefixCoded bytes (is encoded value really an INT?)");
+        return shift;
+    }
+
+    /**
+     * Returns the shift value from a prefix encoded {@code int}.
+     * @throws NumberFormatException if the supplied {@link BytesRef} is
+     * not correctly prefix encoded.
+     */
+    public static int getPrefixCodedIntShift(final BytesRef val) {
+        final int shift = val.bytes[val.offset] - SHIFT_START_INT;
+        if (shift > 31 || shift < 0)
+            throw new NumberFormatException("Invalid shift value in prefixCoded bytes (is encoded value really an INT?)");
+        return shift;
+    }
+
+    /**
+     * Returns a long from prefixCoded bytes.
+     * Rightmost bits will be zero for lower precision codes.
+     * This method can be used to decode a term's value.
+     * @throws NumberFormatException if the supplied {@link BytesRef} is
+     * not correctly prefix encoded.
+     * @see #longToPrefixCoded
+     */
+    public static long prefixCodedToLong(final BytesRef val) {
+        long sortableBits = 0L;
+        for (int i=val.offset+1, limit=val.offset+val.length; i<limit; i++) {
+            sortableBits <<= 7;
+            final byte b = val.bytes[i];
+            if (b < 0) {
+                throw new NumberFormatException(
+                        "Invalid prefixCoded numerical value representation (byte "+
+                                Integer.toHexString(b&0xff)+" at position "+(i-val.offset)+" is invalid)"
+                );
+            }
+            sortableBits |= b;
+        }
+        return (sortableBits << getPrefixCodedLongShift(val)) ^ 0x8000000000000000L;
+    }
+
+    /**
+     * Returns an int from prefixCoded bytes.
+     * Rightmost bits will be zero for lower precision codes.
+     * This method can be used to decode a term's value.
+     * @throws NumberFormatException if the supplied {@link BytesRef} is
+     * not correctly prefix encoded.
+     * @see #intToPrefixCoded
+     */
+    public static int prefixCodedToInt(final BytesRef val) {
+        int sortableBits = 0;
+        for (int i=val.offset+1, limit=val.offset+val.length; i<limit; i++) {
+            sortableBits <<= 7;
+            final byte b = val.bytes[i];
+            if (b < 0) {
+                throw new NumberFormatException(
+                        "Invalid prefixCoded numerical value representation (byte "+
+                                Integer.toHexString(b&0xff)+" at position "+(i-val.offset)+" is invalid)"
+                );
+            }
+            sortableBits |= b;
+        }
+        return (sortableBits << getPrefixCodedIntShift(val)) ^ 0x80000000;
+    }
+
+    /**
+     * Splits a long range recursively.
+     * You may implement a builder that adds clauses to a
+     * {@link org.apache.lucene.search.BooleanQuery} for each call to its
+     * {@link LongRangeBuilder#addRange(BytesRef,BytesRef)}
+     * method.
+     * <p>This method is used by {@link org.apache.solr.legacy.LegacyNumericRangeQuery}.
+     */
+    public static void splitLongRange(final LongRangeBuilder builder,
+                                      final int precisionStep,  final long minBound, final long maxBound
+    ) {
+        splitRange(builder, 64, precisionStep, minBound, maxBound);
+    }
+
+    /**
+     * Splits an int range recursively.
+     * You may implement a builder that adds clauses to a
+     * {@link org.apache.lucene.search.BooleanQuery} for each call to its
+     * {@link IntRangeBuilder#addRange(BytesRef,BytesRef)}
+     * method.
+     * <p>This method is used by {@link org.apache.solr.legacy.LegacyNumericRangeQuery}.
+     */
+    public static void splitIntRange(final IntRangeBuilder builder,
+                                     final int precisionStep,  final int minBound, final int maxBound
+    ) {
+        splitRange(builder, 32, precisionStep, minBound, maxBound);
+    }
+
+    /** This helper does the splitting for both 32 and 64 bit. */
+    private static void splitRange(
+            final Object builder, final int valSize,
+            final int precisionStep, long minBound, long maxBound
+    ) {
+        if (precisionStep < 1)
+            throw new IllegalArgumentException("precisionStep must be >=1");
+        if (minBound > maxBound) return;
+        for (int shift=0; ; shift += precisionStep) {
+            // calculate new bounds for inner precision
+            final long diff = 1L << (shift+precisionStep),
+                    mask = ((1L<<precisionStep) - 1L) << shift;
+            final boolean
+                    hasLower = (minBound & mask) != 0L,
+                    hasUpper = (maxBound & mask) != mask;
+            final long
+                    nextMinBound = (hasLower ? (minBound + diff) : minBound) & ~mask,
+                    nextMaxBound = (hasUpper ? (maxBound - diff) : maxBound) & ~mask;
+            final boolean
+                    lowerWrapped = nextMinBound < minBound,
+                    upperWrapped = nextMaxBound > maxBound;
+
+            if (shift+precisionStep>=valSize || nextMinBound>nextMaxBound || lowerWrapped || upperWrapped) {
+                // We are in the lowest precision or the next precision is not available.
+                addRange(builder, valSize, minBound, maxBound, shift);
+                // exit the split recursion loop
+                break;
+            }
+
+            if (hasLower)
+                addRange(builder, valSize, minBound, minBound | mask, shift);
+            if (hasUpper)
+                addRange(builder, valSize, maxBound & ~mask, maxBound, shift);
+
+            // recurse to next precision
+            minBound = nextMinBound;
+            maxBound = nextMaxBound;
+        }
+    }
+
+    /** Helper that delegates to correct range builder */
+    private static void addRange(
+            final Object builder, final int valSize,
+            long minBound, long maxBound,
+            final int shift
+    ) {
+        // for the max bound set all lower bits (that were shifted away):
+        // this is important for testing or other usages of the splitted range
+        // (e.g. to reconstruct the full range). The prefixEncoding will remove
+        // the bits anyway, so they do not hurt!
+        maxBound |= (1L << shift) - 1L;
+        // delegate to correct range builder
+        switch(valSize) {
+            case 64:
+                ((LongRangeBuilder)builder).addRange(minBound, maxBound, shift);
+                break;
+            case 32:
+                ((IntRangeBuilder)builder).addRange((int)minBound, (int)maxBound, shift);
+                break;
+            default:
+                // Should not happen!
+                throw new IllegalArgumentException("valSize must be 32 or 64.");
+        }
+    }
+
+    /**
+     * Callback for {@link #splitLongRange}.
+     * You need to overwrite only one of the methods.
+     * @lucene.internal
+     * @since 2.9, API changed non backwards-compliant in 4.0
+     */
+    public static abstract class LongRangeBuilder {
+
+        /**
+         * Overwrite this method, if you like to receive the already prefix encoded range bounds.
+         * You can directly build classical (inclusive) range queries from them.
+         */
+        public void addRange(BytesRef minPrefixCoded, BytesRef maxPrefixCoded) {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * Overwrite this method, if you like to receive the raw long range bounds.
+         * You can use this for e.g. debugging purposes (print out range bounds).
+         */
+        public void addRange(final long min, final long max, final int shift) {
+            final BytesRefBuilder minBytes = new BytesRefBuilder(), maxBytes = new BytesRefBuilder();
+            longToPrefixCoded(min, shift, minBytes);
+            longToPrefixCoded(max, shift, maxBytes);
+            addRange(minBytes.get(), maxBytes.get());
+        }
+
+    }
+
+    /**
+     * Callback for {@link #splitIntRange}.
+     * You need to overwrite only one of the methods.
+     * @lucene.internal
+     * @since 2.9, API changed non backwards-compliant in 4.0
+     */
+    public static abstract class IntRangeBuilder {
+
+        /**
+         * Overwrite this method, if you like to receive the already prefix encoded range bounds.
+         * You can directly build classical range (inclusive) queries from them.
+         */
+        public void addRange(BytesRef minPrefixCoded, BytesRef maxPrefixCoded) {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * Overwrite this method, if you like to receive the raw int range bounds.
+         * You can use this for e.g. debugging purposes (print out range bounds).
+         */
+        public void addRange(final int min, final int max, final int shift) {
+            final BytesRefBuilder minBytes = new BytesRefBuilder(), maxBytes = new BytesRefBuilder();
+            intToPrefixCoded(min, shift, minBytes);
+            intToPrefixCoded(max, shift, maxBytes);
+            addRange(minBytes.get(), maxBytes.get());
+        }
+
+    }
+
+    /**
+     * Filters the given {@link TermsEnum} by accepting only prefix coded 64 bit
+     * terms with a shift value of <tt>0</tt>.
+     *
+     * @param termsEnum
+     *          the terms enum to filter
+     * @return a filtered {@link TermsEnum} that only returns prefix coded 64 bit
+     *         terms with a shift value of <tt>0</tt>.
+     */
+    public static TermsEnum filterPrefixCodedLongs(TermsEnum termsEnum) {
+        return new SeekingNumericFilteredTermsEnum(termsEnum) {
+
+            @Override
+            protected AcceptStatus accept(BytesRef term) {
+                return LegacyNumericUtils.getPrefixCodedLongShift(term) == 0 ? AcceptStatus.YES : AcceptStatus.END;
+            }
+        };
+    }
+
+    /**
+     * Filters the given {@link TermsEnum} by accepting only prefix coded 32 bit
+     * terms with a shift value of <tt>0</tt>.
+     *
+     * @param termsEnum
+     *          the terms enum to filter
+     * @return a filtered {@link TermsEnum} that only returns prefix coded 32 bit
+     *         terms with a shift value of <tt>0</tt>.
+     */
+    public static TermsEnum filterPrefixCodedInts(TermsEnum termsEnum) {
+        return new SeekingNumericFilteredTermsEnum(termsEnum) {
+
+            @Override
+            protected AcceptStatus accept(BytesRef term) {
+                return LegacyNumericUtils.getPrefixCodedIntShift(term) == 0 ? AcceptStatus.YES : AcceptStatus.END;
+            }
+        };
+    }
+
+    /** Just like FilteredTermsEnum, except it adds a limited
+     *  seekCeil implementation that only works with {@link
+     *  #filterPrefixCodedInts} and {@link
+     *  #filterPrefixCodedLongs}. */
+    private static abstract class SeekingNumericFilteredTermsEnum extends FilteredTermsEnum {
+        public SeekingNumericFilteredTermsEnum(final TermsEnum tenum) {
+            super(tenum, false);
+        }
+
+        @Override
+        @SuppressWarnings("fallthrough")
+        public SeekStatus seekCeil(BytesRef term) throws IOException {
+
+            // NOTE: This is not general!!  It only handles YES
+            // and END, because that's all we need for the numeric
+            // case here
+
+            SeekStatus status = tenum.seekCeil(term);
+            if (status == SeekStatus.END) {
+                return SeekStatus.END;
+            }
+
+            actualTerm = tenum.term();
+
+            if (accept(actualTerm) == AcceptStatus.YES) {
+                return status;
+            } else {
+                return SeekStatus.END;
+            }
+        }
+    }
+
+    private static Terms intTerms(Terms terms) {
+        return new FilterLeafReader.FilterTerms(terms) {
+            @Override
+            public TermsEnum iterator() throws IOException {
+                return filterPrefixCodedInts(in.iterator());
+            }
+        };
+    }
+
+    private static Terms longTerms(Terms terms) {
+        return new FilterLeafReader.FilterTerms(terms) {
+            @Override
+            public TermsEnum iterator() throws IOException {
+                return filterPrefixCodedLongs(in.iterator());
+            }
+        };
+    }
+
+    /**
+     * Returns the minimum int value indexed into this
+     * numeric field or null if no terms exist.
+     */
+    public static Integer getMinInt(Terms terms) throws IOException {
+        // All shift=0 terms are sorted first, so we don't need
+        // to filter the incoming terms; we can just get the
+        // min:
+        BytesRef min = terms.getMin();
+        return (min != null) ? LegacyNumericUtils.prefixCodedToInt(min) : null;
+    }
+
+    /**
+     * Returns the maximum int value indexed into this
+     * numeric field or null if no terms exist.
+     */
+    public static Integer getMaxInt(Terms terms) throws IOException {
+        BytesRef max = intTerms(terms).getMax();
+        return (max != null) ? LegacyNumericUtils.prefixCodedToInt(max) : null;
+    }
+
+    /**
+     * Returns the minimum long value indexed into this
+     * numeric field or null if no terms exist.
+     */
+    public static Long getMinLong(Terms terms) throws IOException {
+        // All shift=0 terms are sorted first, so we don't need
+        // to filter the incoming terms; we can just get the
+        // min:
+        BytesRef min = terms.getMin();
+        return (min != null) ? LegacyNumericUtils.prefixCodedToLong(min) : null;
+    }
+
+    /**
+     * Returns the maximum long value indexed into this
+     * numeric field or null if no terms exist.
+     */
+    public static Long getMaxLong(Terms terms) throws IOException {
+        BytesRef max = longTerms(terms).getMax();
+        return (max != null) ? LegacyNumericUtils.prefixCodedToLong(max) : null;
+    }
+
+}

--- a/src/test/java/com/github/flaxsearch/resources/TestDocValuesResource.java
+++ b/src/test/java/com/github/flaxsearch/resources/TestDocValuesResource.java
@@ -40,7 +40,7 @@ public class TestDocValuesResource extends IndexResourceTestBase {
         List<String> docValues = resource.client().target("/docvalues/field1/binary").request()
                 .get(new GenericType<List<String>>() {});
 
-        assertThat(docValues).containsExactly("", "some bytes");
+        assertThat(docValues).containsExactly("some bytes");
 
         try {
             resource.client().target("/docvalues/field-thats-not-there/binary").request()
@@ -58,7 +58,7 @@ public class TestDocValuesResource extends IndexResourceTestBase {
     	assertThat(response.getType()).isEqualTo("BINARY");
     	assertThat(response.getValues()).isInstanceOf(Map.class);
     	Map<String,String> values = (Map<String,String>) response.getValues();
-    	assertThat(values.get("0")).isEqualTo("");
+    	assertThat(values.get("0")).isNull();
     	assertThat(values.get("1")).isEqualTo("some bytes");
     }
 
@@ -68,7 +68,7 @@ public class TestDocValuesResource extends IndexResourceTestBase {
                 .get(AnyDocValuesResponse.class);
         assertThat(response.getType()).isEqualTo("SORTED");
         Map<String,Map<String, Object>> values = (Map<String,Map<String, Object>>) response.getValues();
-        assertThat(values.get("0").get("ord")).isEqualTo(-1);
+        assertThat(values.get("0")).isNull();
         assertThat(values.get("1").get("value")).isEqualTo("only in doc 1");
     }
 
@@ -79,7 +79,7 @@ public class TestDocValuesResource extends IndexResourceTestBase {
     	assertThat(response.getType()).isEqualTo("BINARY");
     	assertThat(response.getValues()).isInstanceOf(Map.class);
     	Map<String,String> values = (Map<String,String>) response.getValues();
-    	assertThat(values.get("0")).isEqualTo("");
+    	assertThat(values.get("0")).isNull();
     	assertThat(values.get("1")).isEqualTo("c29tZSBieXRlcw==");
     }
 

--- a/src/test/java/com/github/flaxsearch/testutil/GutenbergIndex.java
+++ b/src/test/java/com/github/flaxsearch/testutil/GutenbergIndex.java
@@ -78,9 +78,6 @@ public class GutenbergIndex {
         document.add(new IntPoint("filesize", data.length));
         document.add(new NumericDocValuesField("filesize", data.length));
         
-        document.add(new LegacyIntField("filesize_lint", data.length, Field.Store.YES));
-        document.add(new LegacyDoubleField("filesize_ldouble", (double) data.length, Field.Store.YES)); 
-
         document.add(new SortedDocValuesField("dv_filepath", new BytesRef(filepath)));
         document.add(new BinaryDocValuesField("dv_filename", new BytesRef(filename)));
         document.add(new SortedNumericDocValuesField("dv_filesize_sorted", data.length));


### PR DESCRIPTION
A number of updates needed to support Lucene 7.0.1. 

Making a PR in the hopes that you'll find it useful. A few things are less than optimal:

   - I copied the source of `LegacyNumericUtils` from `org.apache.solr.legacy`. If you include Solr 7.0.1 as a dependency, you'll end up in JAR hell because of a version conflict in Jackson (dropwizard has a different dependency).
   - I Volkswagoned the `GutenbergIndex` test util by removing the `Legacy*` fields because no legacy numerics are supported. 

On looking at this diff, I realized that this project mixes tabs and spaces. I'll push another commit that moves it all to spaces.