### PR TITLE
Fixed regex filter

### DIFF
--- a/ui/src/components/terms.js
+++ b/ui/src/components/terms.js
@@ -3,6 +3,7 @@ import { Nav, NavItem, FormGroup, FormControl, Radio, Form, Button, Table } from
 import { loadTermsData, getFieldEncoding, setFieldEncoding } from '../data';
 import { EncodingDropdown } from './misc';
 import TermItem from './termitem'
+import { isValidRegExp } from '../util';
 
 const TERMSLISTSTYLE = {
     marginTop: '10px',
@@ -48,6 +49,15 @@ class Terms extends React.Component {
         }
     }
 
+    getValidationState() {
+        if (!this.state.termsFilter) {
+            return null;
+        } else if (isValidRegExp(this.state.termsFilter)) {
+            return "success";
+        } else {
+            return "error";
+        }
+    }
 
     loadAndDisplayData(segment, field, termsFilter, newEncoding) {
         newEncoding = newEncoding || getFieldEncoding(
@@ -66,8 +76,12 @@ class Terms extends React.Component {
             }
         };
 
-        loadTermsData({ segment, field, termsFilter, encoding: newEncoding,
-            count: FETCH_COUNT, onSuccess, onError: this.onError });
+        if (isValidRegExp(termsFilter)) {
+            loadTermsData({ segment, field, termsFilter, encoding: newEncoding,
+                count: FETCH_COUNT, onSuccess, onError: this.onError });
+        } else {
+            this.setState({ termsFilter });
+        }
     }
 
     componentDidMount() {
@@ -187,11 +201,12 @@ class Terms extends React.Component {
                 </tbody>
             </table>
             <Form inline onSubmit={ e => e.preventDefault() }>
-                <FormControl type="text" value={s.termsFilter}
-                             placeholder={'Filter by regexp'}
-                             onChange={ e => this.setTermsFilter(e.target.value) }
-                             style={{width:'75%'}} />
-                {" "}
+                <FormGroup  validationState={ this.getValidationState() }>
+                    <FormControl type="text" value={s.termsFilter}
+                                 placeholder={'Filter by regexp'}
+                                 onChange={ e => this.setTermsFilter(e.target.value) }
+                                 style={{width:'90%'}} />
+                </FormGroup>
                 <EncodingDropdown encoding={s.encoding} numeric={true}
                                   onSelect={x => this.setEncoding(x)} />
             </Form>

--- a/ui/src/util.js
+++ b/ui/src/util.js
@@ -39,3 +39,15 @@ export function parseDoclist(doclist, numDocs) {
   }
   return ret;
 }
+
+/**
+ * Check that regExp compiles to a valid regular expression
+ */
+export function isValidRegExp(regExp) {
+  try {
+    new RegExp(regExp);
+  } catch (e){
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
(Apologies for the spate of PRs in the last couple days.)

The regex search was broken—you couldn't type a `(`  in the filter bar because it was an invalid regex and it would get an error from the server. This does the validation client-side, and uses a `FormGroup` with validation state to alert the user to an error.

Note that the size of the form changed slightly. 

## On success:

<img width="415" alt="screen shot 2017-10-20 at 6 36 18 am" src="https://user-images.githubusercontent.com/8784746/31823556-4e978030-b561-11e7-854e-dda10357607a.png">

## On error: 

<img width="306" alt="screen shot 2017-10-20 at 6 38 05 am" src="https://user-images.githubusercontent.com/8784746/31823573-553bb258-b561-11e7-8a54-7436032c403c.png">
